### PR TITLE
Fix order edit view to show customer name

### DIFF
--- a/routes/admin.js
+++ b/routes/admin.js
@@ -76,7 +76,10 @@ router.get('/orders/create', async (req, res) => {
 
 // Trang chỉnh sửa
 router.get('/orders/:id/edit', async (req, res) => {
-  const order = await Order.findById(req.params.id).lean();
+  const order = await Order.findById(req.params.id)
+    .populate('user_id', 'full_name email')
+    .populate('products.productId', 'name price')
+    .lean();
   res.render('admin/order-form', { layout: 'admin/layout', order, mode: 'edit' });
 });
 

--- a/routes/admin.js
+++ b/routes/admin.js
@@ -65,6 +65,7 @@ router.get('/banner', (req, res) => {
 
 //order
 const Order = require('../models/Order');
+const { transitions } = require('../utils/orderStatus');
 
 // Trang list orders (đã có)
 router.get('/orders', (req, res) => res.render('admin/order', { layout: 'admin/layout' }));
@@ -80,7 +81,7 @@ router.get('/orders/:id/edit', async (req, res) => {
     .populate('user_id', 'full_name email')
     .populate('products.productId', 'name price')
     .lean();
-  res.render('admin/order-form', { layout: 'admin/layout', order, mode: 'edit' });
+  res.render('admin/order-form', { layout: 'admin/layout', order, mode: 'edit', transitions });
 });
 
 

--- a/views/admin/order-form.hbs
+++ b/views/admin/order-form.hbs
@@ -5,7 +5,7 @@
 <link rel="stylesheet" href="/admin/static/css/order.css">
 
 <div class="container mx-auto p-6">
-    <form id="orderForm" data-mode="{{mode}}" data-id="{{order._id}}">
+    <form id="orderForm" data-mode="{{mode}}" data-id="{{order._id}}" data-status="{{order.status}}">
         <div class="mb-4">
             <label class="block">Khách hàng</label>
             <input type="text" name="user_id" value="{{order.user_id.full_name}}" class="input" {{#ifEquals mode 'edit'}}disabled{{/ifEquals}}>
@@ -26,6 +26,13 @@
             <label class="block">Tổng tiền</label>
             <input type="number" name="total" value="{{order.total}}" class="input">
         </div>
+        {{#ifEquals mode 'edit'}}
+        <div class="mb-4">
+            <label class="block">Trạng thái hiện tại</label>
+            <input type="text" value="{{order.status}}" class="input" disabled>
+        </div>
+        <div id="statusButtons" class="flex space-x-2 mb-4"></div>
+        {{/ifEquals}}
         <div class="flex space-x-2">
             <button type="submit" class="btn order-btn">Lưu</button>
             <a href="/admin/orders" class="btn btn-secondary">Hủy</a>
@@ -36,46 +43,7 @@
     </form>
 </div>
 
-<div id="statusButtons"></div>
-
 <script>
-    
-    /**
-   * Gửi yêu cầu cập nhật trạng thái cho orderId
-   * @param {string} orderId 
-   * @param {string} newStatus 
-   */
-async function updateOrderStatus(orderId, newStatus) {
-  if (!newStatus) return;
-  try {
-    const res = await fetch(`/orders/${orderId}/status`, {
-      method: 'PUT',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ status: newStatus })
-    });
-    if (!res.ok) {
-      const { error } = await res.json();
-      return alert('Lỗi cập nhật trạng thái: ' + error);
-    }
-    const updated = await res.json();
-    alert(`Đã chuyển đơn #${orderId} sang trạng thái "${updated.status}"`);
-    // Reload lại danh sách hoặc cập nhật UI tại chỗ
-    window.location.reload();
-  } catch (err) {
-    alert('Lỗi mạng: ' + err.message);
-  }
-}
-
-  // Sau khi load chi tiết đơn (với o.status):
-  const allowed = transitions[o.status] || [];
-  const container = document.getElementById('statusButtons');
-  allowed.forEach(st => {
-    const btn = document.createElement('button');
-    btn.textContent = st.charAt(0).toUpperCase() + st.slice(1);
-    btn.onclick = () => updateOrderStatus(orderId, st);
-    container.appendChild(btn);
-  });
+  window.orderTransitions = {{{json transitions}}};
 </script>
-
-
 <script src="/admin/static/js/order.js"></script>

--- a/views/admin/order-form.hbs
+++ b/views/admin/order-form.hbs
@@ -8,7 +8,7 @@
     <form id="orderForm" data-mode="{{mode}}" data-id="{{order._id}}">
         <div class="mb-4">
             <label class="block">Khách hàng</label>
-            <input type="text" name="user_id" value="{{order.user_id}}" required class="input">
+            <input type="text" name="user_id" value="{{order.user_id.full_name}}" class="input" {{#ifEquals mode 'edit'}}disabled{{/ifEquals}}>
         </div>
         <div class="mb-4">
             <label class="block">Địa chỉ</label>


### PR DESCRIPTION
## Summary
- populate user info when loading edit page
- disable customer field and show full name in edit form
- improve `/orders` API to support search and status filters with populated user data

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_6860aec7b12083319712639b9e035aa9

## Summary by Sourcery

Add filtering and enriched data to order routes and improve the order edit form to display customer names

Enhancements:
- Enhance GET /orders endpoint to filter by status, search by order ID or customer name, populate user full_name and product details, and sort results
- Populate user full_name and email, and product name and price in the admin order edit route
- Update order edit view to display customer full name in a disabled input when editing