### PR TITLE
Add banner popup management

### DIFF
--- a/controllers/bannerCtrl.js
+++ b/controllers/bannerCtrl.js
@@ -13,10 +13,23 @@ exports.getAll = async (req, res, next) => {
 // Tạo banner mới (chỉ khi đã có imageUrl)
 exports.create = async (req, res, next) => {
   try {
-    const { title, imageUrl, link } = req.body;
-    const banner = new Banner({ title, imageUrl, link });
+    const { title, imageUrl, content, link } = req.body;
+    const banner = new Banner({ title, imageUrl, content, link });
     await banner.save();
     res.status(201).json(banner);
+  } catch (err) {
+    next(err);
+  }
+};
+
+// Banner mới nhất còn hoạt động
+exports.getLatest = async (req, res, next) => {
+  try {
+    const banner = await Banner.findOne({ isActive: true })
+      .sort('-createdAt')
+      .lean();
+    if (!banner) return res.status(404).json({});
+    res.json(banner);
   } catch (err) {
     next(err);
   }

--- a/controllers/notificationCtrl.js
+++ b/controllers/notificationCtrl.js
@@ -1,10 +1,12 @@
 const Notification = require('../models/Notification');
+const { send } = require('../utils/notificationStream');
 
 // Tạo thông báo mới
 exports.create = async (req, res) => {
   try {
     const { type, title, message } = req.body;
     const notif = await Notification.create({ type, title, message });
+    send(notif);
     res.status(201).json(notif);
   } catch (err) {
     res.status(400).json({ error: err.message });

--- a/controllers/productCtrl.js
+++ b/controllers/productCtrl.js
@@ -82,15 +82,18 @@ exports.getProducts = async (req, res) => {
     const page  = Math.max(1, +req.query.page  || 1);
     const limit = Math.max(1, +req.query.limit || 20);
     const skip  = (page - 1) * limit;
+    const q     = (req.query.q || '').trim();
+
+    const nameFilter = q ? { name: new RegExp(q, 'i') } : {};
 
     const [products, total] = await Promise.all([
-      Product.find()
+      Product.find(nameFilter)
         .skip(skip)
         .limit(limit)
         .populate('category_id', 'name')
         .populate('brand_id', 'name')
         .lean(),
-      Product.countDocuments()
+      Product.countDocuments(nameFilter)
     ]);
 
     const productsWithImage = await Promise.all(

--- a/models/Banner.js
+++ b/models/Banner.js
@@ -3,6 +3,7 @@ const mongoose = require('mongoose');
 const bannerSchema = new mongoose.Schema({
   title:     { type: String, required: true },
   imageUrl:  { type: String, required: true },
+  content:   { type: String, default: '' },
   link:      { type: String },
   isActive:  { type: Boolean, default: true },
   createdAt: { type: Date, default: Date.now }

--- a/public/admin/static/css/faq.css
+++ b/public/admin/static/css/faq.css
@@ -1,0 +1,4 @@
+.faq-container {
+  margin-top: 2rem;
+  margin-bottom: 2rem;
+}

--- a/public/admin/static/js/admin.js
+++ b/public/admin/static/js/admin.js
@@ -10,15 +10,17 @@ let currentPage = 1;
 let hasMore     = true;
 const limit      = 20;
 let observer; // IntersectionObserver reference
+let productQuery = '';
 
 /**
  * Fetch products from API with pagination
  * @param {number} page - Page number to fetch
  */
-async function fetchProducts(page = 1) {
+async function fetchProducts(page = 1, q = productQuery) {
   if (!hasMore && page !== 1) return;
   try {
-    const res = await fetch(`${apiProduct}?page=${page}&limit=${limit}`);
+    const url = `${apiProduct}?page=${page}&limit=${limit}&q=${encodeURIComponent(q)}`;
+    const res = await fetch(url);
     if (!res.ok) throw new Error(`HTTP error! status: ${res.status}`);
     const { products, hasMore: more } = await res.json();
 
@@ -90,7 +92,29 @@ async function initProductForm() {
   const form            = document.getElementById("productForm");
   const categorySelect  = document.getElementById("categorySelect");
   const specContainer   = document.getElementById("specContainer");
-  if (!form || !categorySelect || !specContainer) return;
+  const descInput       = document.getElementById("descriptionInput");
+  const descEditorEl    = document.getElementById("descriptionEditor");
+  const imageFile       = document.getElementById("imageFile");
+  const imagePreview    = document.getElementById("imagePreview");
+  const imageUrlInput   = document.getElementById("imageUrl");
+  let   quill;
+  if (!form || !categorySelect || !specContainer || !descInput || !descEditorEl) return;
+  quill = new Quill(descEditorEl, { theme: "snow" });
+
+  if (imageFile) {
+    imageFile.addEventListener('change', () => {
+      const file = imageFile.files[0];
+      if (file) {
+        imagePreview.src = URL.createObjectURL(file);
+        imagePreview.style.display = '';
+      }
+    });
+  }
+
+  if (!form.dataset.id) {
+    const hiddenId = form.querySelector("input[name='id']");
+    if (hiddenId) form.dataset.id = hiddenId.value;
+  }
 
   // Load specs when category changes
   categorySelect.addEventListener("change", async () => {
@@ -122,8 +146,12 @@ async function initProductForm() {
       form.querySelector('input[name="name"]').value        = prod.name;
       form.querySelector('input[name="price"]').value       = prod.price;
       form.querySelector('input[name="stock"]').value       = prod.stock;
-      form.querySelector('textarea[name="description"]').value = prod.description || "";
-      form.querySelector('input[name="image"]').value       = prod.image || "";
+      quill.root.innerHTML = prod.description || "";
+      if (imagePreview) {
+        imagePreview.src = prod.image || '';
+        imagePreview.style.display = prod.image ? '' : 'none';
+      }
+      if (imageUrlInput) imageUrlInput.value = prod.image || '';
       categorySelect.value = prod.category_id._id;
       // trigger specs load
       await new Promise(r => setTimeout(r, 0));
@@ -143,14 +171,34 @@ async function initProductForm() {
   // Submit handler
   form.addEventListener("submit", async e => {
     e.preventDefault();
+    descInput.value = quill.root.innerHTML;
     const fd = new FormData(form);
+
+    let imageUrl = imageUrlInput ? imageUrlInput.value : '';
+    if (imageFile && imageFile.files[0]) {
+      const fdImg = new FormData();
+      fdImg.append('image', imageFile.files[0]);
+      try {
+        const upRes = await fetch(`${apiProduct}/upload`, {
+          method: 'POST',
+          body: fdImg
+        });
+        if (upRes.ok) {
+          const data = await upRes.json();
+          imageUrl = data.url;
+        }
+      } catch (err) {
+        console.error('Upload image error:', err);
+      }
+    }
+
     const payload = {
       name           : fd.get("name"),
       category_id    : fd.get("category_id"),
       brand_id       : fd.get("brand_id"),
       price          : parseFloat(fd.get("price")),
       stock          : parseInt(fd.get("stock")),
-      image          : fd.get("image"),
+      image          : imageUrl,
       description    : fd.get("description"),
       specifications : Array.from(form.querySelectorAll(".spec-item input")).map(
         inp => ({ key: inp.previousElementSibling.textContent, value: inp.value })
@@ -214,7 +262,7 @@ function initProductScroll() {
     entries.forEach(entry => {
       if (entry.isIntersecting) {
         observer.unobserve(sentinel);
-        fetchProducts(currentPage + 1);
+        fetchProducts(currentPage + 1, productQuery);
       }
     });
   }, {
@@ -233,6 +281,15 @@ document.addEventListener("DOMContentLoaded", () => {
   if (document.getElementById("productTable")) {
     initProductScroll();
     fetchProducts(1);
+    const search = document.getElementById('searchInput');
+    if (search) {
+      search.addEventListener('input', () => {
+        productQuery = search.value.trim();
+        currentPage = 1;
+        hasMore = true;
+        fetchProducts(1, productQuery);
+      });
+    }
   }
   // Users
   if (document.getElementById("userTable")) fetchUsers();

--- a/public/admin/static/js/banner-popup.js
+++ b/public/admin/static/js/banner-popup.js
@@ -1,0 +1,29 @@
+// Fetch latest banner and show popup on page load
+async function fetchBanner() {
+  try {
+    const res = await fetch('/banners/latest');
+    if (!res.ok) return;
+    const banner = await res.json();
+    if (!banner || !banner.imageUrl) return;
+    showBannerPopup(banner);
+  } catch (err) {
+    console.error('Banner fetch error:', err);
+  }
+}
+
+function showBannerPopup(banner) {
+  const overlay = document.createElement('div');
+  overlay.id = 'bannerOverlay';
+  overlay.className = 'fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50';
+  overlay.innerHTML = `
+    <div class="bg-white rounded shadow-lg p-4 max-w-lg w-full relative">
+      <button id="bannerClose" class="absolute top-2 right-2 text-gray-500">&times;</button>
+      <h2 class="text-xl font-semibold mb-2">${banner.title || ''}</h2>
+      <img src="${banner.imageUrl}" alt="banner" class="mb-2 w-full object-contain">
+      <p class="mb-2">${banner.content || ''}</p>
+    </div>`;
+  document.body.appendChild(overlay);
+  document.getElementById('bannerClose').addEventListener('click', () => overlay.remove());
+}
+
+document.addEventListener('DOMContentLoaded', fetchBanner);

--- a/public/admin/static/js/banner.js
+++ b/public/admin/static/js/banner.js
@@ -20,6 +20,7 @@
               <img src="${b.imageUrl}" class="card-img-top" alt="${b.title}">
               <div class="card-body text-center">
                 <h5 class="card-title">${b.title}</h5>
+                <p class="text-sm my-1">${b.content || ''}</p>
                 <div class="btn-group" role="group">
                   <button class="btn btn-sm btn-outline-secondary"
                           onclick="previewBanner('${b.imageUrl}')">
@@ -44,6 +45,9 @@
     document.getElementById('bannerForm').addEventListener('submit', async e => {
       e.preventDefault();
       const title = document.getElementById('bannerTitle').value.trim();
+      const content = document.getElementById('bannerContent')
+        ? document.getElementById('bannerContent').value.trim()
+        : '';
       const file  = document.getElementById('bannerFile').files[0];
       if (!file) return alert('Chưa chọn file.');
 
@@ -60,7 +64,7 @@
         const createRes = await fetch(BANNER_API, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ title, imageUrl: url })
+          body: JSON.stringify({ title, imageUrl: url, content })
         });
         if (!createRes.ok) {
           const errText = await createRes.text();

--- a/public/admin/static/js/baocao.js
+++ b/public/admin/static/js/baocao.js
@@ -53,4 +53,14 @@ AOS.init({ duration: 600, once: true });
       }
     }
   });
+
+  // render bảng doanh thu theo tháng nếu có phần tử
+  const tableBody = document.getElementById("revenueTable");
+  if (tableBody) {
+    monthly.labels.forEach((label, idx) => {
+      const tr = document.createElement("tr");
+      tr.innerHTML = `<td>${label}</td><td class="text-end">${fmt(monthly.data[idx])}</td>`;
+      tableBody.appendChild(tr);
+    });
+  }
 })();

--- a/public/admin/static/js/user.js
+++ b/public/admin/static/js/user.js
@@ -37,8 +37,9 @@ function renderUsers(users, append = false) {
   if (!append) tbody.innerHTML = '';
   users.forEach(u => {
     const tr = document.createElement('tr');
+    const avatarUrl = u.avatar || 'https://via.placeholder.com/40';
     tr.innerHTML = `
-      <td class="px-6 py-4"><img src="${u.avatar||'/admin/static/images/default-avatar.png'}" alt="" class="w-10 h-10 rounded-full"></td>
+      <td class="px-6 py-4"><img src="${avatarUrl}" alt="avatar" class="w-10 h-10 rounded-full object-cover"></td>
       <td class="px-6 py-4">${u.name}</td>
       <td class="px-6 py-4">${u.email}</td>
       <td class="px-6 py-4">${u.role}</td>

--- a/routes/admin.js
+++ b/routes/admin.js
@@ -63,8 +63,14 @@ router.get('/banner', (req, res) => {
   res.render('admin/qlbanner', { layout: 'admin/layout' });
 });
 
+// FAQ page
+router.get('/faq', (req, res) => {
+  res.render('admin/faq', { layout: 'admin/layout' });
+});
+
 //order
 const Order = require('../models/Order');
+const { transitions } = require('../utils/orderStatus');
 
 // Trang list orders (đã có)
 router.get('/orders', (req, res) => res.render('admin/order', { layout: 'admin/layout' }));
@@ -76,8 +82,11 @@ router.get('/orders/create', async (req, res) => {
 
 // Trang chỉnh sửa
 router.get('/orders/:id/edit', async (req, res) => {
-  const order = await Order.findById(req.params.id).lean();
-  res.render('admin/order-form', { layout: 'admin/layout', order, mode: 'edit' });
+  const order = await Order.findById(req.params.id)
+    .populate('user_id', 'full_name email')
+    .populate('products.productId', 'name price')
+    .lean();
+  res.render('admin/order-form', { layout: 'admin/layout', order, mode: 'edit', transitions });
 });
 
 

--- a/routes/banners.js
+++ b/routes/banners.js
@@ -21,6 +21,7 @@ const upload = multer({ storage });
 
 // CRUD banner
 router.get('/', ctrl.getAll);
+router.get('/latest', ctrl.getLatest);
 router.post('/', ctrl.create);
 router.delete('/:id', ctrl.delete);
 

--- a/routes/notifications.js
+++ b/routes/notifications.js
@@ -1,10 +1,12 @@
 const express = require('express');
 const router  = express.Router();
 const ctrl    = require('../controllers/notificationCtrl');
+const stream  = require('../utils/notificationStream');
 
 router.post('/',     ctrl.create);
 router.get('/',      ctrl.list);
 router.patch('/:id/read', ctrl.markRead);
 router.delete('/:id',     ctrl.remove);
+router.get('/stream', (req, res) => stream.addClient(res));
 
 module.exports = router;

--- a/routes/products.js
+++ b/routes/products.js
@@ -1,8 +1,32 @@
 const express = require('express');
 const router  = express.Router();
+const path    = require('path');
+const fs      = require('fs');
+const multer  = require('multer');
 const ctrl    = require('../controllers/productCtrl');
 
+// Ensure uploads directory exists
+const uploadDir = path.join(__dirname, '../uploads/products');
+fs.mkdirSync(uploadDir, { recursive: true });
+
+const storage = multer.diskStorage({
+  destination: (req, file, cb) => cb(null, uploadDir),
+  filename: (req, file, cb) => {
+    const uniq = Date.now() + '-' + Math.round(Math.random() * 1e9);
+    cb(null, uniq + path.extname(file.originalname));
+  }
+});
+const upload = multer({ storage });
+
 router.get('/',    ctrl.getProducts);
+// Upload product image (needs to come before "/:id" route)
+router.post('/upload', upload.single('image'), (req, res) => {
+  if (!req.file) {
+    return res.status(400).json({ error: 'No file uploaded' });
+  }
+  const url = `/uploads/products/${req.file.filename}`;
+  res.json({ url });
+});
 router.get('/:id', ctrl.getProductById);
 router.post('/',   ctrl.createProduct);
 router.put('/:id', ctrl.updateProduct);

--- a/routes/users.js
+++ b/routes/users.js
@@ -3,6 +3,7 @@ const router = express.Router();
 const bcrypt = require('bcryptjs');
 const jwt = require('jsonwebtoken');
 const User = require('../models/userModel');
+const Banner = require('../models/Banner');
 require('dotenv').config();
 
 const multer = require('multer');
@@ -79,6 +80,10 @@ router.post('/login', async (req, res) => {
       { expiresIn: process.env.JWT_EXPIRES_IN }
     );
 
+    const banner = await Banner.findOne({ isActive: true })
+      .sort('-createdAt')
+      .lean();
+
     res.status(200).json({
       message: 'Login successful',
       token,
@@ -87,7 +92,8 @@ router.post('/login', async (req, res) => {
         full_name: user.full_name,
         email: user.email,
         role: user.role
-      }
+      },
+      banner
     });
 
   } catch (err) {
@@ -150,8 +156,12 @@ router.get('/', async (req, res) => {
     ]);
     res.json({
       users: users.map(u => ({
-        _id: u._id, name: u.full_name, email: u.email,
-        role: u.role, active: u.active, avatar: u.avatar
+        _id   : u._id,
+        name  : u.full_name,
+        email : u.email,
+        role  : u.role,
+        active: u.active,
+        avatar: u.avatarUrl
       })),
       hasMore: skip + users.length < total
     });

--- a/utils/notificationStream.js
+++ b/utils/notificationStream.js
@@ -1,0 +1,26 @@
+const clients = new Set();
+
+function addClient(res) {
+  res.set({
+    'Content-Type': 'text/event-stream',
+    'Cache-Control': 'no-cache',
+    Connection: 'keep-alive'
+  });
+  res.flushHeaders();
+
+  clients.add(res);
+  res.write('retry: 10000\n\n');
+
+  res.on('close', () => {
+    clients.delete(res);
+  });
+}
+
+function send(notification) {
+  const data = `data: ${JSON.stringify(notification)}\n\n`;
+  for (const res of clients) {
+    res.write(data);
+  }
+}
+
+module.exports = { addClient, send };

--- a/views/admin/baocao.hbs
+++ b/views/admin/baocao.hbs
@@ -58,8 +58,20 @@
       </div>
     </div>
 
-    <div class="chart-container mb-5" data-aos="fade-up" data-aos-delay="150">
+    <div class="chart-container mb-4" data-aos="fade-up" data-aos-delay="150">
       <canvas id="revenueChart" height="120"></canvas>
+    </div>
+
+    <div class="table-responsive" data-aos="fade-up" data-aos-delay="300">
+      <table class="table table-striped">
+        <thead>
+          <tr>
+            <th>Tháng</th>
+            <th class="text-end">Doanh thu</th>
+          </tr>
+        </thead>
+        <tbody id="revenueTable"></tbody>
+      </table>
     </div>
   </main>
 
@@ -85,77 +97,6 @@
     defer
   ></script>
 
-  <!-- Inline script: chạy sau khi tất cả đã load -->
-  <script defer>
-    document.addEventListener('DOMContentLoaded', async () => {
-      // 1. Khởi động AOS
-      AOS.init({ duration: 600, once: true });
-
-      console.log('⚡ baocao page: bắt đầu fetch API');
-      // 2. Gọi API đúng đường dẫn
-      const [sumRes, monRes] = await Promise.all([
-        fetch('/reports/summary'),
-        fetch('/reports/monthly'),
-      ]);
-
-      if (!sumRes.ok || !monRes.ok) {
-        console.error('❌ Fetch lỗi:', sumRes.status, monRes.status);
-        return;
-      }
-
-      const summary = await sumRes.json();
-      const monthly = await monRes.json();
-      console.log('⤷ summary:', summary, '\n⤷ monthly:', monthly);
-
-      // 3. Render CountUp
-      const fmt = v =>
-        new Intl.NumberFormat('vi-VN', {
-          style: 'currency',
-          currency: 'VND',
-        }).format(v);
-
-      new CountUp('revenue', summary.revenue, {
-        duration: 1.2,
-        formattingFn: fmt,
-      }).start();
-      new CountUp('orders', summary.orders, { duration: 1.2 }).start();
-      new CountUp('avgRevenue', summary.avgRevenue, {
-        duration: 1.2,
-        formattingFn: fmt,
-      }).start();
-
-      // 4. Vẽ Chart.js
-      const ctx = document
-        .getElementById('revenueChart')
-        .getContext('2d');
-      const grad = ctx.createLinearGradient(0, 0, 0, 200);
-      grad.addColorStop(0, 'rgba(0,98,255,0.5)');
-      grad.addColorStop(1, 'rgba(0,98,255,0)');
-
-      new Chart(ctx, {
-        type: 'line',
-        data: {
-          labels: monthly.labels,
-          datasets: [
-            {
-              data: monthly.data,
-              backgroundColor: grad,
-              borderColor: 'var(--bs-primary)',
-              fill: true,
-              tension: 0.3,
-            },
-          ],
-        },
-        options: {
-          responsive: true,
-          plugins: { legend: { display: false } },
-          scales: {
-            y: { beginAtZero: true, ticks: { callback: fmt } },
-            x: { grid: { display: false } },
-          },
-        },
-      });
-    });
-  </script>
-</body>
+  <script src="/admin/static/js/baocao.js" defer></script>
+  </body>
 </html>

--- a/views/admin/category-form.hbs
+++ b/views/admin/category-form.hbs
@@ -1,23 +1,26 @@
 <!-- File: views/admin/category-form.hbs -->
 {{#*inline "title"}}{{#if category._id}}Chỉnh sửa Danh mục{{else}}Tạo Danh mục{{/if}}{{/inline}}
 
-<form id="categoryForm">
-  {{#if category._id}}
-    <input type="hidden" name="id" value="{{category._id}}">
-  {{/if}}
-  <div class="form-group">
-    <label>Tên danh mục</label>
-    <input type="text" name="name" value="{{category.name}}" required>
-  </div>
-  <div class="form-group">
-    <label>Mô tả</label>
-    <textarea name="description">{{category.description}}</textarea>
-  </div>
-  <div class="modal-footer">
-    <button type="submit" class="btn">Lưu</button>
-    <a href="/admin/categories" class="btn btn-secondary">Hủy</a>
-  </div>
-</form>
+<link rel="stylesheet" href="/admin/static/css/form.css">
+<div class="form-scroll-container">
+  <form id="categoryForm">
+    {{#if category._id}}
+      <input type="hidden" name="id" value="{{category._id}}">
+    {{/if}}
+    <div class="form-group">
+      <label>Tên danh mục</label>
+      <input type="text" name="name" value="{{category.name}}" required>
+    </div>
+    <div class="form-group">
+      <label>Mô tả</label>
+      <textarea name="description">{{category.description}}</textarea>
+    </div>
+    <div class="modal-footer">
+      <button type="submit" class="btn btn-primary">Lưu</button>
+      <a href="/admin/categories" class="btn btn-secondary">Hủy</a>
+    </div>
+  </form>
+</div>
 
 <script>
   document.addEventListener('DOMContentLoaded', initCategoryForm);

--- a/views/admin/faq.hbs
+++ b/views/admin/faq.hbs
@@ -1,0 +1,47 @@
+{{#*inline "title"}}FAQ{{/inline}}
+<link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+<link rel="stylesheet" href="/admin/static/css/faq.css">
+
+<div class="container faq-container">
+  <h2 class="mb-4">Câu hỏi thường gặp</h2>
+  <div class="accordion" id="faqAccordion">
+    <div class="accordion-item">
+      <h2 class="accordion-header" id="faqHeadingOne">
+        <button class="accordion-button" type="button" data-bs-toggle="collapse" data-bs-target="#faq1" aria-expanded="true" aria-controls="faq1">
+          Làm sao để tạo sản phẩm mới?
+        </button>
+      </h2>
+      <div id="faq1" class="accordion-collapse collapse show" aria-labelledby="faqHeadingOne" data-bs-parent="#faqAccordion">
+        <div class="accordion-body">
+          Vào mục <strong>Sản phẩm</strong> và nhấn nút <em>Tạo sản phẩm</em>, điền đầy đủ thông tin rồi lưu lại.
+        </div>
+      </div>
+    </div>
+    <div class="accordion-item">
+      <h2 class="accordion-header" id="faqHeadingTwo">
+        <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#faq2" aria-expanded="false" aria-controls="faq2">
+          Tôi có thể chỉnh sửa trạng thái đơn hàng ở đâu?
+        </button>
+      </h2>
+      <div id="faq2" class="accordion-collapse collapse" aria-labelledby="faqHeadingTwo" data-bs-parent="#faqAccordion">
+        <div class="accordion-body">
+          Truy cập trang <strong>Đơn hàng</strong>, chọn đơn cần chỉnh sửa và sử dụng các nút thay đổi trạng thái trong phần chi tiết đơn.
+        </div>
+      </div>
+    </div>
+    <div class="accordion-item">
+      <h2 class="accordion-header" id="faqHeadingThree">
+        <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#faq3" aria-expanded="false" aria-controls="faq3">
+          Làm thế nào gửi thông báo đến người dùng?
+        </button>
+      </h2>
+      <div id="faq3" class="accordion-collapse collapse" aria-labelledby="faqHeadingThree" data-bs-parent="#faqAccordion">
+        <div class="accordion-body">
+          Trong mục <strong>Thông báo</strong> bạn điền nội dung và nhấn <em>Tạo Thông Báo</em>. Người dùng đang trực tuyến sẽ nhận ngay lập tức.
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js" defer></script>

--- a/views/admin/form.hbs
+++ b/views/admin/form.hbs
@@ -3,6 +3,7 @@
 {{/inline}}
 
 <link rel="stylesheet" href="/admin/static/css/form.css">
+<link href="https://cdn.quilljs.com/1.3.6/quill.snow.css" rel="stylesheet">
 <div class="form-scroll-container">
   <form id="productForm" data-mode="{{mode}}">
     {{#ifEquals mode 'edit'}}
@@ -63,13 +64,16 @@
     </div>
 
     <div class="form-group">
-      <label>URL ảnh</label>
-      <input type="url" name="image" value="{{product.image}}">
+      <label>Ảnh sản phẩm</label>
+      <input type="file" id="imageFile" accept="image/*">
+      <img id="imagePreview" src="{{product.image}}" class="h-24 my-2" {{#unless product.image}}style="display:none"{{/unless}}>
+      <input type="hidden" name="image" id="imageUrl" value="{{product.image}}">
     </div>
 
     <div class="form-group">
       <label>Mô tả</label>
-      <textarea name="description" rows="3">{{product.description}}</textarea>
+      <div id="descriptionEditor" style="height:150px"></div>
+      <input type="hidden" name="description" id="descriptionInput">
     </div>
 
     <div class="modal-footer">
@@ -79,6 +83,7 @@
   </form>
 </div>
 
+<script src="https://cdn.quilljs.com/1.3.6/quill.js"></script>
 <script>
   document.addEventListener('DOMContentLoaded', initProductForm);
 </script>

--- a/views/admin/layout.hbs
+++ b/views/admin/layout.hbs
@@ -103,5 +103,6 @@ Z
     <script src="https://cdn.tailwindcss.com"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/particles.js/2.0.0/particles.min.js"></script>
     <script src="/admin/static/js/admin.js"></script>
+    <script src="/admin/static/js/banner-popup.js"></script>
   </body>
 </html>

--- a/views/admin/order-form.hbs
+++ b/views/admin/order-form.hbs
@@ -5,10 +5,10 @@
 <link rel="stylesheet" href="/admin/static/css/order.css">
 
 <div class="container mx-auto p-6">
-    <form id="orderForm" data-mode="{{mode}}" data-id="{{order._id}}">
+    <form id="orderForm" data-mode="{{mode}}" data-id="{{order._id}}" data-status="{{order.status}}">
         <div class="mb-4">
             <label class="block">Khách hàng</label>
-            <input type="text" name="user_id" value="{{order.user_id}}" required class="input">
+            <input type="text" name="user_id" value="{{order.user_id.full_name}}" class="input" {{#ifEquals mode 'edit'}}disabled{{/ifEquals}}>
         </div>
         <div class="mb-4">
             <label class="block">Địa chỉ</label>
@@ -26,6 +26,13 @@
             <label class="block">Tổng tiền</label>
             <input type="number" name="total" value="{{order.total}}" class="input">
         </div>
+        {{#ifEquals mode 'edit'}}
+        <div class="mb-4">
+            <label class="block">Trạng thái hiện tại</label>
+            <input type="text" value="{{order.status}}" class="input" disabled>
+        </div>
+        <div id="statusButtons" class="flex space-x-2 mb-4"></div>
+        {{/ifEquals}}
         <div class="flex space-x-2">
             <button type="submit" class="btn order-btn">Lưu</button>
             <a href="/admin/orders" class="btn btn-secondary">Hủy</a>
@@ -36,46 +43,7 @@
     </form>
 </div>
 
-<div id="statusButtons"></div>
-
 <script>
-    
-    /**
-   * Gửi yêu cầu cập nhật trạng thái cho orderId
-   * @param {string} orderId 
-   * @param {string} newStatus 
-   */
-async function updateOrderStatus(orderId, newStatus) {
-  if (!newStatus) return;
-  try {
-    const res = await fetch(`/orders/${orderId}/status`, {
-      method: 'PUT',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ status: newStatus })
-    });
-    if (!res.ok) {
-      const { error } = await res.json();
-      return alert('Lỗi cập nhật trạng thái: ' + error);
-    }
-    const updated = await res.json();
-    alert(`Đã chuyển đơn #${orderId} sang trạng thái "${updated.status}"`);
-    // Reload lại danh sách hoặc cập nhật UI tại chỗ
-    window.location.reload();
-  } catch (err) {
-    alert('Lỗi mạng: ' + err.message);
-  }
-}
-
-  // Sau khi load chi tiết đơn (với o.status):
-  const allowed = transitions[o.status] || [];
-  const container = document.getElementById('statusButtons');
-  allowed.forEach(st => {
-    const btn = document.createElement('button');
-    btn.textContent = st.charAt(0).toUpperCase() + st.slice(1);
-    btn.onclick = () => updateOrderStatus(orderId, st);
-    container.appendChild(btn);
-  });
+  window.orderTransitions = {{{json transitions}}};
 </script>
-
-
 <script src="/admin/static/js/order.js"></script>

--- a/views/admin/order.hbs
+++ b/views/admin/order.hbs
@@ -43,6 +43,7 @@
 
 <script>
   let currentStatus = '';
+  let currentOrders = [];
 
   // Lấy cấu hình tabs từ server
   async function fetchStatusTabs() {
@@ -56,7 +57,9 @@
     if (status) url += `status=${status}&`;
     if (query) url += `q=${encodeURIComponent(query)}`;
     const res = await fetch(url);
-    return res.json();
+    const data = await res.json();
+    currentOrders = Array.isArray(data) ? data : [];
+    return currentOrders;
   }
 
   // Ánh xạ màu cho status badge
@@ -87,8 +90,8 @@
       btn.onclick = async () => {
         currentStatus = tab.key;
         document.getElementById('searchInput').value = '';
-        const orders = await fetchOrders(currentStatus);
-        renderOrders(orders);
+        await fetchOrders(currentStatus);
+        renderOrders(currentOrders);
         renderStatusTabs(tabs);
       };
       container.appendChild(btn);
@@ -141,14 +144,14 @@
   document.addEventListener('DOMContentLoaded', async () => {
     const tabs = await fetchStatusTabs();
     renderStatusTabs(tabs);
-    const orders = await fetchOrders();
-    renderOrders(orders);
+    await fetchOrders();
+    renderOrders(currentOrders);
 
     // Tìm kiếm theo input
     document.getElementById('searchInput').addEventListener('input', async e => {
       const q = e.target.value.trim();
-      const data = await fetchOrders(currentStatus, q);
-      renderOrders(data);
+      await fetchOrders(currentStatus, q);
+      renderOrders(currentOrders);
     });
   });
 </script>

--- a/views/admin/products-static.hbs
+++ b/views/admin/products-static.hbs
@@ -42,6 +42,15 @@
   document.addEventListener('DOMContentLoaded', () => {
     initProductScroll();
     fetchProducts(1);
+    const search = document.getElementById('searchInput');
+    if (search) {
+      search.addEventListener('input', () => {
+        productQuery = search.value.trim();
+        currentPage = 1;
+        hasMore = true;
+        fetchProducts(1, productQuery);
+      });
+    }
   });
 
 </script>

--- a/views/admin/products.hbs
+++ b/views/admin/products.hbs
@@ -19,5 +19,16 @@
 </table>
 
 <script>
-  document.addEventListener('DOMContentLoaded', fetchProducts);
+  document.addEventListener('DOMContentLoaded', () => {
+    fetchProducts(1);
+    const search = document.getElementById('searchInput');
+    if (search) {
+      search.addEventListener('input', () => {
+        productQuery = search.value.trim();
+        currentPage = 1;
+        hasMore = true;
+        fetchProducts(1, productQuery);
+      });
+    }
+  });
 </script>

--- a/views/admin/qlbanner.hbs
+++ b/views/admin/qlbanner.hbs
@@ -78,6 +78,10 @@
               <label for="bannerFile" class="form-label">Chọn hình</label>
               <input type="file" id="bannerFile" class="form-control" accept="image/*" required>
             </div>
+            <div class="mb-3">
+              <label for="bannerContent" class="form-label">Nội dung</label>
+              <textarea id="bannerContent" class="form-control" rows="3"></textarea>
+            </div>
           </div>
           <div class="modal-footer">
             <button type="submit" class="btn btn-primary">
@@ -174,6 +178,7 @@
                 <small class="text-muted d-block mb-2">
                   ${new Date(b.createdAt).toLocaleDateString('vi-VN')}
                 </small>
+                <p class="text-sm mb-2">${b.content || ''}</p>
                 <div class="btn-group" role="group">
                   <button class="btn btn-sm btn-outline-secondary"
                           onclick="previewBanner('${fullImageUrl}', '${b.title}')"
@@ -211,6 +216,7 @@
       const submitBtn = e.target.querySelector('button[type="submit"]');
       const spinner = document.getElementById('submitSpinner');
       const title = document.getElementById('bannerTitle').value.trim();
+      const content = document.getElementById('bannerContent').value.trim();
       const file = document.getElementById('bannerFile').files[0];
       
       if (!file) {
@@ -249,7 +255,7 @@
         const createRes = await fetch(BANNER_API, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ title, imageUrl: url })
+          body: JSON.stringify({ title, imageUrl: url, content })
         });
         
         if (!createRes.ok) {

--- a/views/admin/thongbao.hbs
+++ b/views/admin/thongbao.hbs
@@ -4,6 +4,33 @@
 
 <div class="container my-5">
   <h2 class="mb-4">Thông Báo</h2>
+  <div class="card mb-4">
+    <div class="card-header">Tạo Thông Báo</div>
+    <div class="card-body">
+      <form id="createForm" class="row g-3">
+        <div class="col-md-3">
+          <label class="form-label">Loại</label>
+          <select id="typeInput" class="form-select">
+            <option value="success">Success</option>
+            <option value="info">Info</option>
+            <option value="warning">Warning</option>
+            <option value="danger">Danger</option>
+          </select>
+        </div>
+        <div class="col-md-4">
+          <label class="form-label">Tiêu đề</label>
+          <input id="titleInput" class="form-control" required>
+        </div>
+        <div class="col-md-5">
+          <label class="form-label">Nội dung</label>
+          <input id="messageInput" class="form-control" required>
+        </div>
+        <div class="col-12 text-end">
+          <button class="btn btn-primary" type="submit">Gửi</button>
+        </div>
+      </form>
+    </div>
+  </div>
   <!-- Toast container -->
   <div id="toastContainer" class="position-fixed top-0 end-0 p-3" style="z-index: 1055;"></div>
 
@@ -67,6 +94,33 @@
       // Hiển thị toast với những thông báo mới
       notifications.filter(n => !n.isRead).forEach(n => {
         notify(n.type, n.title, n.message);
+      });
+
+      // Lắng nghe thông báo mới qua SSE
+      const es = new EventSource('/notifications/stream');
+      es.onmessage = ev => {
+        const n = JSON.parse(ev.data);
+        notifications.unshift(n);
+        renderList();
+        notify(n.type, n.title, n.message);
+      };
+
+      const form = document.getElementById('createForm');
+      form.addEventListener('submit', async e => {
+        e.preventDefault();
+        const payload = {
+          type: document.getElementById('typeInput').value,
+          title: document.getElementById('titleInput').value,
+          message: document.getElementById('messageInput').value
+        };
+        const resp = await fetch('/notifications', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(payload)
+        });
+        if (resp.ok) {
+          form.reset();
+        }
       });
     } catch (err) {
       console.error(err);


### PR DESCRIPTION
## Summary
- extend banner model with `content`
- return latest active banner and include in login API
- allow admin banner creation with content field
- render banner content in list cards
- inject `banner-popup.js` in admin layout to show popup on login
- create FAQ page accessible via `/admin/faq`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_6860aec7b12083319712639b9e035aa9

## Summary by Sourcery

Extend banner capabilities with a content field, active-banner API and client-side popup; add an admin FAQ page; enhance product CRUD with rich-text descriptions, image uploads and search; introduce real-time notifications via SSE; support order filtering and status transitions in admin UI; refactor frontend scripts into standalone files and enrich reports and listing UIs.

New Features:
- Add banner content field and management endpoints including getLatest and popup display on admin login
- Introduce FAQ page under /admin/faq with common questions
- Enable rich-text product descriptions with Quill and image uploads via a new /products/upload endpoint
- Add SSE-based real-time notifications with admin create form and /notifications/stream
- Surface order status transition buttons in the admin order form driven by server-defined transitions

Enhancements:
- Allow search and pagination filters on products and orders via query parameters
- Extract inline page scripts into external JS modules (admin.js, baocao.js, order.js, banner-popup.js)
- Enhance reports page with a monthly revenue table rendered from external script
- Improve user list avatars with fallback and style category form with dedicated CSS
- Return active banner in login API response

Documentation:
- Add user-facing FAQ page under admin layout