### PR TITLE
Improve revenue report layout

### DIFF
--- a/public/admin/static/css/baocao.css
+++ b/public/admin/static/css/baocao.css
@@ -1,0 +1,21 @@
+.chart-fullscreen {
+  width: 100vw;
+  height: 70vh;
+  margin-left: calc(50% - 50vw);
+  position: relative;
+}
+.chart-fullscreen canvas {
+  width: 100% !important;
+  height: 100% !important;
+}
+.param-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  align-items: flex-end;
+  margin-bottom: 1rem;
+}
+.param-row > * {
+  flex: 1;
+  min-width: 150px;
+}

--- a/views/admin/baocao.hbs
+++ b/views/admin/baocao.hbs
@@ -5,6 +5,8 @@
 <!-- AOS & Animate.css -->
 <link href="https://cdnjs.cloudflare.com/ajax/libs/animate.css/4.1.1/animate.min.css" rel="stylesheet">
 <link href="https://cdnjs.cloudflare.com/ajax/libs/aos/2.3.4/aos.css" rel="stylesheet">
+<!-- Custom CSS for báo cáo -->
+<link rel="stylesheet" href="/admin/static/css/baocao.css" />
 
 <header class="bg-light py-3 mb-4">
   <div class="container">
@@ -12,7 +14,7 @@
   </div>
 </header>
 
-<main class="container">
+<main class="container-fluid px-4">
   <div class="row text-center mb-5" data-aos="fade-up">
     <div class="col-md-4 mb-4">
       <div class="card p-4 shadow-sm">
@@ -40,28 +42,20 @@
     </div>
   </div>
 
-  <div class="row g-2 align-items-end mb-3" data-aos="fade-up" data-aos-delay="120">
-    <div class="col-md-4">
+  <div class="param-row" data-aos="fade-up" data-aos-delay="120">
       <select id="periodSelect" class="form-select">
         <option value="month" selected>Theo tháng</option>
         <option value="week">Theo tuần</option>
         <option value="year">Theo năm</option>
       </select>
-    </div>
-    <div class="col-md-4">
       <input type="month" id="monthInput" class="form-control" />
       <input type="week" id="weekInput" class="form-control d-none" />
       <input type="number" id="yearInput" class="form-control d-none" min="2000" max="2100" />
-    </div>
-    <div class="col-md-4">
-      <button id="loadRevenue" class="btn btn-primary w-100">Xem</button>
-    </div>
+      <button id="loadRevenue" class="btn btn-primary">Xem</button>
   </div>
 
-  <div class="chart-container mb-4" data-aos="fade-up" data-aos-delay="150">
-
-    <canvas id="revenueChart" height="240"></canvas>
-
+  <div class="chart-fullscreen mb-4" data-aos="fade-up" data-aos-delay="150">
+    <canvas id="revenueChart"></canvas>
   </div>
 
   <div class="row g-2 align-items-end mb-4" data-aos="fade-up" data-aos-delay="200">


### PR DESCRIPTION
## Summary
- add CSS for full-screen revenue chart
- adjust revenue report view to use new layout

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_68636f0a64348331b95aa2cd12400a9a

## Summary by Sourcery

Enhance revenue report layout by using a fluid container, full-screen chart, and a flexible parameter row styled via a new CSS file.

Enhancements:
- Introduce a new `baocao.css` file to define `.chart-fullscreen` and `.param-row` styles for full-width charts and responsive controls.
- Update report template to switch from container and grid classes to `container-fluid`, `chart-fullscreen`, and `param-row` layout classes.