### PR TITLE
Improve revenue report layout

### DIFF
--- a/public/admin/static/css/baocao.css
+++ b/public/admin/static/css/baocao.css
@@ -1,0 +1,342 @@
+        :root {
+            --primary-gradient: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+            --secondary-gradient: linear-gradient(135deg, #f093fb 0%, #f5576c 100%);
+            --success-gradient: linear-gradient(135deg, #4facfe 0%, #00f2fe 100%);
+            --warning-gradient: linear-gradient(135deg, #ffecd2 0%, #fcb69f 100%);
+            --info-gradient: linear-gradient(135deg, #a8edea 0%, #fed6e3 100%);
+            --card-shadow: 0 10px 30px rgba(0, 0, 0, 0.1);
+            --card-hover-shadow: 0 20px 40px rgba(0, 0, 0, 0.15);
+            --border-radius: 16px;
+            --transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: 'Inter', sans-serif;
+            background: linear-gradient(135deg, #f5f7fa 0%, #c3cfe2 100%);
+            min-height: 100vh;
+            line-height: 1.6;
+        }
+
+        /* Header Styles */
+        .premium-header {
+            background: var(--primary-gradient);
+            color: white;
+            padding: 2rem 0;
+            box-shadow: var(--card-shadow);
+            position: relative;
+            overflow: hidden;
+        }
+
+        .premium-header::before {
+            content: '';
+            position: absolute;
+            top: 0;
+            left: 0;
+            right: 0;
+            bottom: 0;
+            background: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100"><defs><pattern id="grain" width="100" height="100" patternUnits="userSpaceOnUse"><circle cx="25" cy="25" r="1" fill="white" opacity="0.1"/><circle cx="75" cy="75" r="1" fill="white" opacity="0.1"/><circle cx="50" cy="10" r="0.5" fill="white" opacity="0.1"/></pattern></defs><rect width="100" height="100" fill="url(%23grain)"/></svg>');
+            opacity: 0.1;
+        }
+
+        .premium-header h1 {
+            font-weight: 700;
+            font-size: 2.5rem;
+            text-shadow: 0 2px 4px rgba(0, 0, 0, 0.3);
+            position: relative;
+            z-index: 1;
+        }
+
+        /* Stats Cards */
+        .stats-section {
+            margin-top: -3rem;
+            position: relative;
+            z-index: 10;
+        }
+
+        .stat-card {
+            background: white;
+            border-radius: var(--border-radius);
+            box-shadow: var(--card-shadow);
+            transition: var(--transition);
+            border: none;
+            overflow: hidden;
+            position: relative;
+        }
+
+        .stat-card:hover {
+            transform: translateY(-5px);
+            box-shadow: var(--card-hover-shadow);
+        }
+
+        .stat-card::before {
+            content: '';
+            position: absolute;
+            top: 0;
+            left: 0;
+            right: 0;
+            height: 4px;
+            background: var(--primary-gradient);
+        }
+
+        .stat-card.success::before {
+            background: var(--success-gradient);
+        }
+
+        .stat-card.warning::before {
+            background: var(--warning-gradient);
+        }
+
+        .stat-card.info::before {
+            background: var(--info-gradient);
+        }
+
+        .stat-value {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            background: var(--primary-gradient);
+            -webkit-background-clip: text;
+            -webkit-text-fill-color: transparent;
+            background-clip: text;
+        }
+
+        .stat-card.success .stat-value {
+            background: var(--success-gradient);
+            -webkit-background-clip: text;
+            -webkit-text-fill-color: transparent;
+            background-clip: text;
+        }
+
+        .stat-card.warning .stat-value {
+            background: var(--warning-gradient);
+            -webkit-background-clip: text;
+            -webkit-text-fill-color: transparent;
+            background-clip: text;
+        }
+
+        .stat-card.info .stat-value {
+            background: var(--info-gradient);
+            -webkit-background-clip: text;
+            -webkit-text-fill-color: transparent;
+            background-clip: text;
+        }
+
+        .stat-label {
+            color: #6b7280;
+            font-weight: 500;
+            font-size: 0.95rem;
+        }
+
+        .stat-icon {
+            position: absolute;
+            top: 1.5rem;
+            right: 1.5rem;
+            font-size: 2rem;
+            opacity: 0.1;
+        }
+
+        /* Controls Section */
+        .controls-section {
+            background: white;
+            border-radius: var(--border-radius);
+            box-shadow: var(--card-shadow);
+            padding: 2rem;
+            margin: 2rem 0;
+        }
+
+        .controls-title {
+            font-size: 1.25rem;
+            font-weight: 600;
+            margin-bottom: 1.5rem;
+            color: #374151;
+            display: flex;
+            align-items: center;
+            gap: 0.5rem;
+        }
+
+        .form-select, .form-control {
+            border-radius: 12px;
+            border: 2px solid #e5e7eb;
+            padding: 0.75rem 1rem;
+            font-weight: 500;
+            transition: var(--transition);
+        }
+
+        .form-select:focus, .form-control:focus {
+            border-color: #667eea;
+            box-shadow: 0 0 0 3px rgba(102, 126, 234, 0.1);
+        }
+
+        .btn-primary {
+            background: var(--primary-gradient);
+            border: none;
+            border-radius: 12px;
+            padding: 0.75rem 2rem;
+            font-weight: 600;
+            transition: var(--transition);
+            box-shadow: 0 4px 15px rgba(102, 126, 234, 0.3);
+        }
+
+        .btn-primary:hover {
+            transform: translateY(-2px);
+            box-shadow: 0 8px 25px rgba(102, 126, 234, 0.4);
+        }
+
+        /* Chart Sections */
+        .chart-section {
+            background: white;
+            border-radius: var(--border-radius);
+            box-shadow: var(--card-shadow);
+            padding: 2rem;
+            margin: 2rem 0;
+        }
+
+        .chart-title {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 1.5rem;
+            color: #374151;
+            display: flex;
+            align-items: center;
+            gap: 0.5rem;
+        }
+
+        .chart-container {
+            position: relative;
+            height: 400px;
+            margin: 1rem 0;
+        }
+
+        .chart-container.large {
+            height: 500px;
+        }
+
+        .chart-container canvas {
+            border-radius: 12px;
+        }
+
+        /* Comparison Section */
+        .comparison-controls {
+            display: grid;
+            grid-template-columns: 1fr 1fr auto;
+            gap: 1rem;
+            align-items: end;
+            margin-bottom: 2rem;
+        }
+
+        @media (max-width: 768px) {
+            .comparison-controls {
+                grid-template-columns: 1fr;
+            }
+        }
+
+        /* Table Styles */
+        .table-section {
+            background: white;
+            border-radius: var(--border-radius);
+            box-shadow: var(--card-shadow);
+            overflow: hidden;
+        }
+
+        .table-section .table-title {
+            background: var(--primary-gradient);
+            color: white;
+            padding: 1.5rem 2rem;
+            margin: 0;
+            font-size: 1.25rem;
+            font-weight: 600;
+            display: flex;
+            align-items: center;
+            gap: 0.5rem;
+        }
+
+        .table {
+            margin: 0;
+        }
+
+        .table thead th {
+            background: #f8fafc;
+            border: none;
+            font-weight: 600;
+            color: #374151;
+            padding: 1rem 1.5rem;
+        }
+
+        .table tbody td {
+            padding: 1rem 1.5rem;
+            border-color: #f1f5f9;
+            vertical-align: middle;
+        }
+
+        .table tbody tr:hover {
+            background: #f8fafc;
+        }
+
+        /* Responsive Design */
+        @media (max-width: 768px) {
+            .premium-header h1 {
+                font-size: 2rem;
+            }
+
+            .stat-value {
+                font-size: 2rem;
+            }
+
+            .controls-section {
+                padding: 1.5rem;
+            }
+
+            .chart-section {
+                padding: 1.5rem;
+            }
+
+            .chart-container {
+                height: 300px;
+            }
+
+            .chart-container.large {
+                height: 350px;
+            }
+        }
+
+        /* Loading Animation */
+        .loading-spinner {
+            display: none;
+            justify-content: center;
+            align-items: center;
+            height: 200px;
+        }
+
+        .spinner {
+            width: 40px;
+            height: 40px;
+            border: 4px solid #f3f4f6;
+            border-top: 4px solid #667eea;
+            border-radius: 50%;
+            animation: spin 1s linear infinite;
+        }
+
+        @keyframes spin {
+            0% { transform: rotate(0deg); }
+            100% { transform: rotate(360deg); }
+        }
+
+        /* Fade in animation */
+        .fade-in {
+            opacity: 0;
+            transform: translateY(20px);
+            animation: fadeIn 0.6s ease-out forwards;
+        }
+
+        @keyframes fadeIn {
+            to {
+                opacity: 1;
+                transform: translateY(0);
+            }
+        }

--- a/views/admin/baocao.hbs
+++ b/views/admin/baocao.hbs
@@ -1,103 +1,173 @@
 {{#*inline "title"}}Báo cáo Thống kê Doanh thu{{/inline}}
 
 <!-- Bootstrap CSS -->
-<link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+<link href="https://cdnjs.cloudflare.com/ajax/libs/bootstrap/5.3.0/css/bootstrap.min.css" rel="stylesheet">
 <!-- AOS & Animate.css -->
 <link href="https://cdnjs.cloudflare.com/ajax/libs/animate.css/4.1.1/animate.min.css" rel="stylesheet">
 <link href="https://cdnjs.cloudflare.com/ajax/libs/aos/2.3.4/aos.css" rel="stylesheet">
+<!-- Premium font -->
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+<!-- Icons -->
+<link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" rel="stylesheet">
+<!-- Custom CSS for báo cáo -->
+<link rel="stylesheet" href="/admin/static/css/baocao.css" />
 
-<header class="bg-light py-3 mb-4">
-  <div class="container">
-    <h1 class="h3 mb-0">📊 Báo cáo Doanh thu</h1>
-  </div>
+<header class="premium-header">
+    <div class="container">
+        <h1 class="text-center">
+            <i class="fas fa-chart-line me-3"></i>
+            Báo cáo Thống kê Doanh thu
+        </h1>
+    </div>
 </header>
 
-<main class="container">
-  <div class="row text-center mb-5" data-aos="fade-up">
-    <div class="col-md-4 mb-4">
-      <div class="card p-4 shadow-sm">
-        <div class="card-body">
-          <div id="revenue" class="display-5 text-success mb-2">0₫</div>
-          <div class="text-muted">Tổng doanh thu</div>
+<main class="container-fluid px-3 px-md-4">
+    <!-- Stats Section -->
+    <section class="stats-section">
+        <div class="row g-4" data-aos="fade-up">
+            <div class="col-lg-4 col-md-6">
+                <div class="card stat-card success h-100">
+                    <div class="card-body p-4">
+                        <i class="fas fa-dollar-sign stat-icon text-success"></i>
+                        <div id="revenue" class="stat-value">0₫</div>
+                        <div class="stat-label">Tổng doanh thu</div>
+                    </div>
+                </div>
+            </div>
+            <div class="col-lg-4 col-md-6">
+                <div class="card stat-card warning h-100">
+                    <div class="card-body p-4">
+                        <i class="fas fa-shopping-cart stat-icon text-warning"></i>
+                        <div id="orders" class="stat-value">0</div>
+                        <div class="stat-label">Tổng đơn hàng</div>
+                    </div>
+                </div>
+            </div>
+            <div class="col-lg-4 col-md-12">
+                <div class="card stat-card info h-100">
+                    <div class="card-body p-4">
+                        <i class="fas fa-chart-bar stat-icon text-info"></i>
+                        <div id="avgRevenue" class="stat-value">0₫</div>
+                        <div class="stat-label">Doanh thu trung bình</div>
+                    </div>
+                </div>
+            </div>
         </div>
-      </div>
-    </div>
-    <div class="col-md-4 mb-4">
-      <div class="card p-4 shadow-sm">
-        <div class="card-body">
-          <div id="orders" class="display-5 text-warning mb-2">0</div>
-          <div class="text-muted">Tổng đơn hàng</div>
+    </section>
+
+    <!-- Filter Controls -->
+    <section class="controls-section" data-aos="fade-up" data-aos-delay="100">
+        <h3 class="controls-title">
+            <i class="fas fa-filter"></i>
+            Bộ lọc thời gian
+        </h3>
+        <div class="row g-3 align-items-end">
+            <div class="col-md-3">
+                <label class="form-label fw-semibold">Loại thống kê</label>
+                <select id="periodSelect" class="form-select">
+                    <option value="month" selected>Theo tháng</option>
+                    <option value="week">Theo tuần</option>
+                    <option value="year">Theo năm</option>
+                </select>
+            </div>
+            <div class="col-md-3">
+                <label class="form-label fw-semibold">Chọn thời gian</label>
+                <input type="month" id="monthInput" class="form-control" />
+                <input type="week" id="weekInput" class="form-control d-none" />
+                <input type="number" id="yearInput" class="form-control d-none" min="2000" max="2100" placeholder="Năm" />
+            </div>
+            <div class="col-md-3">
+                <button id="loadRevenue" class="btn btn-primary w-100">
+                    <i class="fas fa-search me-2"></i>
+                    Xem báo cáo
+                </button>
+            </div>
         </div>
-      </div>
-    </div>
-    <div class="col-md-4 mb-4">
-      <div class="card p-4 shadow-sm">
-        <div class="card-body">
-          <div id="avgRevenue" class="display-5 text-info mb-2">0₫</div>
-          <div class="text-muted">Doanh thu trung bình</div>
+    </section>
+
+    <!-- Main Chart -->
+    <section class="chart-section" data-aos="fade-up" data-aos-delay="150">
+        <h3 class="chart-title">
+            <i class="fas fa-line-chart"></i>
+            Biểu đồ doanh thu
+        </h3>
+        <div class="chart-container large">
+            <canvas id="revenueChart"></canvas>
         </div>
-      </div>
-    </div>
-  </div>
+    </section>
 
-  <div class="row g-2 align-items-end mb-3" data-aos="fade-up" data-aos-delay="120">
-    <div class="col-md-4">
-      <select id="periodSelect" class="form-select">
-        <option value="month" selected>Theo tháng</option>
-        <option value="week">Theo tuần</option>
-        <option value="year">Theo năm</option>
-      </select>
-    </div>
-    <div class="col-md-4">
-      <input type="month" id="monthInput" class="form-control" />
-      <input type="week" id="weekInput" class="form-control d-none" />
-      <input type="number" id="yearInput" class="form-control d-none" min="2000" max="2100" />
-    </div>
-    <div class="col-md-4">
-      <button id="loadRevenue" class="btn btn-primary w-100">Xem</button>
-    </div>
-  </div>
+    <!-- Comparison Section -->
+    <section class="chart-section" data-aos="fade-up" data-aos-delay="200">
+        <h3 class="chart-title">
+            <i class="fas fa-balance-scale"></i>
+            So sánh doanh thu
+        </h3>
+        <div class="comparison-controls">
+            <div>
+                <label class="form-label fw-semibold">Tháng thứ nhất</label>
+                <select id="month1" class="form-select" aria-label="Tháng so sánh 1">
+                    <option value="">Chọn tháng...</option>
+                </select>
+            </div>
+            <div>
+                <label class="form-label fw-semibold">Tháng thứ hai</label>
+                <select id="month2" class="form-select" aria-label="Tháng so sánh 2">
+                    <option value="">Chọn tháng...</option>
+                </select>
+            </div>
+            <div>
+                <button id="compareBtn" class="btn btn-primary w-100">
+                    <i class="fas fa-chart-column me-2"></i>
+                    So sánh
+                </button>
+            </div>
+        </div>
+        <div class="chart-container">
+            <canvas id="compareChart"></canvas>
+        </div>
+    </section>
 
-  <div class="chart-container mb-4" data-aos="fade-up" data-aos-delay="150">
-
-    <canvas id="revenueChart" height="240"></canvas>
-
-  </div>
-
-  <div class="row g-2 align-items-end mb-4" data-aos="fade-up" data-aos-delay="200">
-    <div class="col-md-4">
-      <select id="month1" class="form-select" aria-label="Tháng so sánh 1"></select>
-    </div>
-    <div class="col-md-4">
-      <select id="month2" class="form-select" aria-label="Tháng so sánh 2"></select>
-    </div>
-    <div class="col-md-4">
-      <button id="compareBtn" class="btn btn-primary w-100">So sánh</button>
-    </div>
-  </div>
-
-  <div class="chart-container mb-4" data-aos="fade-up" data-aos-delay="250">
-
-    <canvas id="compareChart" height="180"></canvas>
-
-  </div>
-
-  <div class="table-responsive" data-aos="fade-up" data-aos-delay="300">
-    <table class="table table-striped">
-      <thead>
-        <tr>
-          <th>Tháng</th>
-          <th class="text-end">Doanh thu</th>
-        </tr>
-      </thead>
-      <tbody id="revenueTable"></tbody>
-    </table>
-  </div>
+    <!-- Revenue Table -->
+    <section class="table-section" data-aos="fade-up" data-aos-delay="250">
+        <h3 class="table-title">
+            <i class="fas fa-table"></i>
+            Bảng chi tiết doanh thu
+        </h3>
+        <div class="table-responsive">
+            <table class="table table-hover">
+                <thead>
+                    <tr>
+                        <th>
+                            <i class="fas fa-calendar me-2"></i>
+                            Thời gian
+                        </th>
+                        <th class="text-end">
+                            <i class="fas fa-money-bill-wave me-2"></i>
+                            Doanh thu
+                        </th>
+                    </tr>
+                </thead>
+                <tbody id="revenueTable">
+                    <tr>
+                        <td colspan="2" class="text-center text-muted py-4">
+                            <i class="fas fa-info-circle me-2"></i>
+                            Chọn thời gian và nhấn "Xem báo cáo" để hiển thị dữ liệu
+                        </td>
+                    </tr>
+                </tbody>
+            </table>
+        </div>
+    </section>
 </main>
 
-<!-- JS dependencies -->
-<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js" defer></script>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/aos/2.3.4/aos.js" defer></script>
-<script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.js" defer></script>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/countup.js/2.9.0/countUp.umd.js" defer></script>
-<script src="/admin/static/js/baocao.js" defer></script>
+<!-- Loading Spinner -->
+<div class="loading-spinner" id="loadingSpinner">
+    <div class="spinner"></div>
+</div>
+
+<!-- Scripts -->
+<script src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap/5.3.0/js/bootstrap.bundle.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/aos/2.3.4/aos.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/4.4.0/chart.umd.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/countup.js/2.9.0/countUp.umd.js"></script>
+<script src="/admin/static/js/baocao.js"></script>


### PR DESCRIPTION
## Summary
- replace revenue report HTML with full premium template
- update CSS to premium theme
- include demo chart and data script

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_68636f0a64348331b95aa2cd12400a9a

## Summary by Sourcery

Apply a premium-themed layout to the revenue report, revamp styles with a new CSS theme, and embed a demo script that animates counters and renders sample revenue charts and tables.

New Features:
- Replace the revenue report page with a premium-styled HTML template and custom iconography
- Include a demo data script that seeds animated counters and Chart.js charts with sample revenue figures
- Add interactive month selection and comparison controls with a loading spinner

Enhancements:
- Add a dedicated baocao.css file for responsive premium styling
- Remove live data fetching and replace it with sample-driven rendering logic using CountUp and Chart.js