### PR TITLE
Add admin login page with role validation

### DIFF
--- a/app.js
+++ b/app.js
@@ -68,12 +68,13 @@ hbs.registerHelper('ifEquals', function (a, b, options) {
 });
 
 // Đăng ký helper JSON stringify
-hbs.registerHelper('json', function (context) {
-  return JSON.stringify(context);
-});
+  hbs.registerHelper('json', function (context) {
+    return JSON.stringify(context);
+  });
 
-app.use('/admin', adminRouter);
-app.use('/users', usersRouter);
+app.use('/', indexRouter);
+  app.use('/admin', adminRouter);
+  app.use('/users', usersRouter);
 app.use('/category', categorysRouter);
 app.use('/product', productsRouter);
 app.use('/orders', ordersRouter);

--- a/public/js/login.js
+++ b/public/js/login.js
@@ -1,0 +1,24 @@
+document.getElementById('loginForm').addEventListener('submit', async (e) => {
+  e.preventDefault();
+  const email = document.getElementById('email').value.trim();
+  const password = document.getElementById('password').value;
+  const errorEl = document.getElementById('error');
+  errorEl.textContent = '';
+  try {
+    const res = await fetch('/users/login', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email, password })
+    });
+    const data = await res.json();
+    if (!res.ok) throw new Error(data.message || 'Login failed');
+    if (data.user.role !== 'admin') {
+      errorEl.textContent = 'Tài khoản không có quyền truy cập.';
+      return;
+    }
+    localStorage.setItem('token', data.token);
+    window.location.href = '/admin';
+  } catch (err) {
+    errorEl.textContent = err.message;
+  }
+});

--- a/routes/index.js
+++ b/routes/index.js
@@ -6,4 +6,9 @@ router.get('/', function(req, res, next) {
   res.render('index', { title: 'Express' });
 });
 
+// Trang đăng nhập Admin
+router.get('/login', function (req, res) {
+  res.render('login', { title: 'Login' });
+});
+
 module.exports = router;

--- a/routes/users.js
+++ b/routes/users.js
@@ -73,6 +73,10 @@ router.post('/login', async (req, res) => {
     const isMatch = await bcrypt.compare(password, user.password);
     if (!isMatch) return res.status(400).json({ message: 'Invalid credentials' });
 
+    if (user.role !== 'admin') {
+      return res.status(403).json({ message: 'Invalid role' });
+    }
+
     // Generate JWT
     const token = jwt.sign(
       { userId: user._id, role: user.role },

--- a/views/login.hbs
+++ b/views/login.hbs
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="vi">
+<head>
+  <meta charset="UTF-8">
+  <title>Admin Login</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+</head>
+<body class="container py-5">
+  <h1 class="mb-4">Đăng nhập Admin</h1>
+  <form id="loginForm" class="mb-3" style="max-width:400px;">
+    <div class="mb-3">
+      <label for="email" class="form-label">Email</label>
+      <input type="email" class="form-control" id="email" required>
+    </div>
+    <div class="mb-3">
+      <label for="password" class="form-label">Mật khẩu</label>
+      <input type="password" class="form-control" id="password" required>
+    </div>
+    <button type="submit" class="btn btn-primary">Đăng nhập</button>
+    <div id="error" class="text-danger mt-3"></div>
+  </form>
+  <script src="/js/login.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add simple admin login page
- enforce admin role in `/users/login`
- expose login page at `/login`
- serve index router

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_6864aa968bc88331916abf8f696140a6

## Summary by Sourcery

Add an admin login flow with role-based validation, expose the login page at `/login`, and serve the index router for the root path.

New Features:
- Expose a dedicated admin login page at `/login` with a Handlebars template and client-side JS to submit credentials.
- Implement client-side form handling to fetch `/users/login` and redirect authenticated admins to the admin area.

Enhancements:
- Enforce an `admin` role check in the `/users/login` endpoint to block non-admin users with a 403 response.
- Mount and serve the index router on `/` before other route handlers.