### PR TITLE
Add user creation page in admin

### DIFF
--- a/public/admin/static/js/user-form.js
+++ b/public/admin/static/js/user-form.js
@@ -1,0 +1,47 @@
+const API_REGISTER = '/users/register';
+const API_USER = '/users';
+
+document.addEventListener('DOMContentLoaded', () => {
+  const form = document.getElementById('userForm');
+  if (!form) return;
+  form.addEventListener('submit', async e => {
+    e.preventDefault();
+    const fd = new FormData(form);
+    const id = fd.get('id');
+    let url, method, payload;
+    if (id) {
+      url = `${API_USER}/${id}`;
+      method = 'PUT';
+      payload = {
+        full_name: fd.get('full_name'),
+        phone: fd.get('phone') || '',
+        address: fd.get('address') || ''
+      };
+    } else {
+      url = API_REGISTER;
+      method = 'POST';
+      payload = {
+        full_name: fd.get('full_name'),
+        email: fd.get('email'),
+        password: fd.get('password'),
+        phone: fd.get('phone') || '',
+        address: fd.get('address') || ''
+      };
+    }
+    try {
+      const res = await fetch(url, {
+        method,
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload)
+      });
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
+        alert('Lỗi: ' + (data.message || res.status));
+        return;
+      }
+      window.location.href = '/admin/users';
+    } catch (err) {
+      alert('Lỗi: ' + err.message);
+    }
+  });
+});

--- a/routes/admin.js
+++ b/routes/admin.js
@@ -5,6 +5,7 @@ const Product = require('../models/Product');
 const Category = require('../models/Category');
 const Brand = require('../models/Brand');
 const TsktProduct = require('../models/TsktProduct');
+const User = require('../models/userModel');
 
 // Dashboard
 router.get('/', (req, res) => {
@@ -14,6 +15,13 @@ router.get('/', (req, res) => {
 // Quản lý Người dùng (static + JS fetch)
 router.get('/users', (req, res) => {
   res.render('admin/user', { layout: 'admin/layout' });
+});
+router.get('/users/create', (req, res) => {
+  res.render('admin/user-form', { layout: 'admin/layout', user: {} });
+});
+router.get('/users/:id/edit', async (req, res) => {
+  const user = await User.findById(req.params.id).lean();
+  res.render('admin/user-form', { layout: 'admin/layout', user });
 });
 
 // Quản lý Sản phẩm

--- a/views/admin/user-form.hbs
+++ b/views/admin/user-form.hbs
@@ -1,0 +1,39 @@
+{{#*inline "title"}}
+  {{#if user._id}}Chỉnh sửa Người dùng{{else}}Tạo Người dùng{{/if}}
+{{/inline}}
+
+<link rel="stylesheet" href="/admin/static/css/form.css">
+<div class="form-scroll-container">
+  <form id="userForm">
+    {{#if user._id}}
+      <input type="hidden" name="id" value="{{user._id}}">
+    {{/if}}
+    <div class="form-group">
+      <label>Họ tên</label>
+      <input type="text" name="full_name" value="{{user.full_name}}" required>
+    </div>
+    <div class="form-group">
+      <label>Email</label>
+      <input type="email" name="email" value="{{user.email}}" {{#if user._id}}disabled{{/if}} required>
+    </div>
+    {{#unless user._id}}
+    <div class="form-group">
+      <label>Mật khẩu</label>
+      <input type="password" name="password" required>
+    </div>
+    {{/unless}}
+    <div class="form-group">
+      <label>Số điện thoại</label>
+      <input type="text" name="phone" value="{{user.phone}}">
+    </div>
+    <div class="form-group">
+      <label>Địa chỉ</label>
+      <input type="text" name="address" value="{{user.address}}">
+    </div>
+    <div class="modal-footer">
+      <button type="submit" class="btn btn-primary">Lưu</button>
+      <a href="/admin/users" class="btn btn-secondary">Hủy</a>
+    </div>
+  </form>
+</div>
+<script src="/admin/static/js/user-form.js"></script>


### PR DESCRIPTION
## Summary
- create `user-form` view
- add client script to handle user form submission
- expose routes to show create/edit user forms

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_6864aaba42708331b8b3c1d30d28c6cf

## Summary by Sourcery

Add a user creation and editing interface to the admin panel, including server routes, form template, and client-side submission handling.

New Features:
- Add admin routes to render user creation and editing forms
- Create a Handlebars template for the user-form view with conditional fields
- Implement client-side JavaScript to submit user data for creation and update