### PR TITLE
Add Google login API

### DIFF
--- a/models/userModel.js
+++ b/models/userModel.js
@@ -14,9 +14,16 @@ const userSchema = new mongoose.Schema({
     lowercase: true,
     trim: true
   },
+  firebaseUid: {
+    type: String,
+    unique: true,
+    sparse: true
+  },
   password: {
     type: String,
-    required: true
+    required: function () {
+      return !this.firebaseUid;
+    }
   },
   phone: {
     type: String,

--- a/routes/users.js
+++ b/routes/users.js
@@ -105,6 +105,54 @@ router.post('/login', async (req, res) => {
   }
 });
 
+// Google login
+router.post('/google-login', async (req, res) => {
+  try {
+    const { firebaseUid, full_name, email, avatarUrl } = req.body;
+
+    if (!firebaseUid || !email) {
+      return res.status(400).json({ message: 'Missing firebaseUid or email' });
+    }
+
+    let user = await User.findOne({ firebaseUid });
+
+    if (!user) {
+      user = await User.findOne({ email });
+    }
+
+    if (!user) {
+      user = new User({ firebaseUid, full_name, email, avatarUrl });
+    } else {
+      if (!user.firebaseUid) user.firebaseUid = firebaseUid;
+      if (full_name && !user.full_name) user.full_name = full_name;
+      if (avatarUrl) user.avatarUrl = avatarUrl;
+    }
+
+    await user.save();
+
+    const token = jwt.sign(
+      { userId: user._id, role: user.role },
+      process.env.JWT_SECRET,
+      { expiresIn: process.env.JWT_EXPIRES_IN }
+    );
+
+    res.status(200).json({
+      message: 'Login successful',
+      token,
+      user: {
+        id: user._id,
+        full_name: user.full_name,
+        email: user.email,
+        avatarUrl: user.avatarUrl,
+        role: user.role
+      }
+    });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ message: 'Server error', error: err.message });
+  }
+});
+
 // Get all users
 router.get('/all', async (req, res) => {
   try {


### PR DESCRIPTION
## Summary
- allow optional password using firebase UID in `User` schema
- implement `/users/google-login` endpoint for Firebase sign-in

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_6864bba8ccb48331ae5d2284df6fcb8e

## Summary by Sourcery

Enable Google login by integrating Firebase UID into the user model and providing a dedicated endpoint to authenticate users and issue JWT tokens.

New Features:
- Add firebaseUid field to User schema and allow password to be optional when using Firebase authentication
- Implement /users/google-login endpoint to handle Firebase-based sign-in/up and return JWT tokens