### PR TITLE
Add banner edit feature

### DIFF
--- a/controllers/bannerCtrl.js
+++ b/controllers/bannerCtrl.js
@@ -57,3 +57,31 @@ exports.uploadImage = (req, res) => {
   }
 };
 
+// Lấy banner theo id
+exports.getById = async (req, res, next) => {
+  try {
+    const banner = await Banner.findById(req.params.id);
+    if (!banner) return res.status(404).json({});
+    res.json(banner);
+  } catch (err) {
+    next(err);
+  }
+};
+
+// Chỉnh sửa banner
+exports.update = async (req, res, next) => {
+  try {
+    const { title, imageUrl, content, link, isActive } = req.body;
+    const updates = { title, imageUrl, content, link, isActive };
+    const banner = await Banner.findByIdAndUpdate(
+      req.params.id,
+      updates,
+      { new: true, runValidators: true }
+    );
+    if (!banner) return res.status(404).json({ error: 'Không tìm thấy banner' });
+    res.json(banner);
+  } catch (err) {
+    next(err);
+  }
+};
+

--- a/public/admin/static/js/banner.js
+++ b/public/admin/static/js/banner.js
@@ -4,6 +4,7 @@ const BannerManager = {
   // API endpoints
   UPLOAD_API: '/banners/upload',
   BANNER_API: '/banners',
+  currentId: null,
 
   // Initialize: tải banner và gắn event
   init() {
@@ -69,18 +70,23 @@ const BannerManager = {
               <h5 class="card-title">${title}</h5>
               <small class="text-muted d-block mb-2">${createdDate}</small>
               <p class="card-text flex-grow-1">${content}</p>
-              <div class="btn-group mt-auto" role="group">
-                <button class="btn btn-sm btn-outline-primary"
-                        onclick="BannerManager.previewBanner('${fullImageUrl}', '${title}')"
-                        title="Xem trước">
-                  <i class="bi bi-eye"></i>
-                </button>
-                <button class="btn btn-sm btn-outline-danger"
-                        onclick="BannerManager.deleteBanner('${banner._id}')"
-                        title="Xóa">
-                  <i class="bi bi-trash"></i>
-                </button>
-              </div>
+                <div class="btn-group mt-auto" role="group">
+                  <button class="btn btn-sm btn-outline-primary"
+                          onclick="BannerManager.previewBanner('${fullImageUrl}', '${title}')"
+                          title="Xem trước">
+                    <i class="bi bi-eye"></i>
+                  </button>
+                  <button class="btn btn-sm btn-outline-secondary"
+                          onclick="BannerManager.editBanner('${banner._id}')"
+                          title="Sửa">
+                    <i class="bi bi-pencil"></i>
+                  </button>
+                  <button class="btn btn-sm btn-outline-danger"
+                          onclick="BannerManager.deleteBanner('${banner._id}')"
+                          title="Xóa">
+                    <i class="bi bi-trash"></i>
+                  </button>
+                </div>
             </div>
           </div>`;
         container.appendChild(col);
@@ -110,6 +116,10 @@ const BannerManager = {
     modalEl.addEventListener('hidden.bs.modal', () => {
       form.reset();
       this.clearErrors();
+      this.currentId = null;
+      document.getElementById('previewCurrent').classList.add('d-none');
+      document.getElementById('bannerFile').required = true;
+      document.getElementById('addBannerModalLabel').textContent = 'Thêm Banner';
     });
   },
 
@@ -137,7 +147,7 @@ const BannerManager = {
     document.getElementById('fileError').textContent = '';
   },
 
-  // Xử lý submit tạo mới banner
+  // Xử lý submit tạo/sửa banner
   async handleSubmit(e) {
     e.preventDefault();
     this.clearErrors();
@@ -145,13 +155,14 @@ const BannerManager = {
     const title = document.getElementById('bannerTitle').value.trim();
     const content = document.getElementById('bannerContent').value.trim();
     const file = document.getElementById('bannerFile').files[0];
+    const isEdit = !!this.currentId;
     let hasError = false;
 
     if (!title) {
       document.getElementById('titleError').textContent = 'Vui lòng nhập tiêu đề.';
       hasError = true;
     }
-    if (!file) {
+    if (!file && !isEdit) {
       document.getElementById('fileError').textContent = 'Vui lòng chọn file hình ảnh.';
       hasError = true;
     }
@@ -163,36 +174,71 @@ const BannerManager = {
     spinner.classList.remove('d-none');
 
     try {
-      // Upload ảnh
-      const formData = new FormData();
-      formData.append('image', file);
-      const uploadRes = await fetch(this.UPLOAD_API, {
-        method: 'POST',
-        body: formData
-      });
-      if (!uploadRes.ok) throw new Error(`Upload failed: ${uploadRes.status}`);
-      const { url } = await uploadRes.json();
+      let imageUrl = '';
+      if (file) {
+        const formData = new FormData();
+        formData.append('image', file);
+        const uploadRes = await fetch(this.UPLOAD_API, { method: 'POST', body: formData });
+        if (!uploadRes.ok) throw new Error(`Upload failed: ${uploadRes.status}`);
+        const data = await uploadRes.json();
+        imageUrl = data.url;
+      }
 
-      // Tạo record banner
-      const createRes = await fetch(this.BANNER_API, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ title, content, imageUrl: url })
-      });
-      if (!createRes.ok) throw new Error(`Create failed: ${createRes.status}`);
+      if (isEdit) {
+        const payload = { title, content };
+        if (imageUrl) payload.imageUrl = imageUrl;
+        const updateRes = await fetch(`${this.BANNER_API}/${this.currentId}`, {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(payload)
+        });
+        if (!updateRes.ok) throw new Error(`Update failed: ${updateRes.status}`);
+      } else {
+        const createRes = await fetch(this.BANNER_API, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ title, content, imageUrl })
+        });
+        if (!createRes.ok) throw new Error(`Create failed: ${createRes.status}`);
+      }
 
       // Thành công: refresh list và đóng modal
       document.getElementById('bannerForm').reset();
+      this.currentId = null;
+      document.getElementById('bannerFile').required = true;
+      document.getElementById('previewCurrent').classList.add('d-none');
       this.loadBanners();
       const bsModal = bootstrap.Modal.getInstance(document.getElementById('addBannerModal'));
       bsModal.hide();
-      this.showToast('Thêm banner thành công!', 'success');
+      document.getElementById('addBannerModalLabel').textContent = 'Thêm Banner';
+      this.showToast(isEdit ? 'Cập nhật banner thành công!' : 'Thêm banner thành công!', 'success');
     } catch (err) {
       console.error('Lỗi tạo banner:', err);
       this.showToast(`Lỗi tạo banner: ${err.message}`, 'danger');
     } finally {
       submitBtn.disabled = false;
       spinner.classList.add('d-none');
+    }
+  },
+
+  // Mở modal chỉnh sửa banner
+  async editBanner(id) {
+    try {
+      const res = await fetch(`${this.BANNER_API}/${id}`);
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      const banner = await res.json();
+      document.getElementById('bannerTitle').value = banner.title || '';
+      document.getElementById('bannerContent').value = banner.content || '';
+      const preview = document.getElementById('previewCurrent');
+      preview.src = this.getFullImageUrl(banner.imageUrl);
+      preview.classList.remove('d-none');
+      document.getElementById('bannerFile').required = false;
+      document.getElementById('addBannerModalLabel').textContent = 'Sửa Banner';
+      this.currentId = id;
+      new bootstrap.Modal(document.getElementById('addBannerModal')).show();
+    } catch (err) {
+      console.error('Lỗi tải banner:', err);
+      this.showToast('Không thể tải banner', 'danger');
     }
   },
 

--- a/routes/banners.js
+++ b/routes/banners.js
@@ -23,9 +23,8 @@ const upload = multer({ storage });
 router.get('/', ctrl.getAll);
 router.get('/latest', ctrl.getLatest);
 router.post('/', ctrl.create);
-router.delete('/:id', ctrl.delete);
 
-// ★ Upload endpoint ★
+// ★ Upload endpoint (đặt trước các route "/:id") ★
 router.post('/upload',
   upload.single('image'),
   (req, res) => {
@@ -37,5 +36,9 @@ router.post('/upload',
     res.json({ url });
   }
 );
+
+router.get('/:id', ctrl.getById);
+router.put('/:id', ctrl.update);
+router.delete('/:id', ctrl.delete);
 
 module.exports = router;

--- a/views/admin/qlbanner.hbs
+++ b/views/admin/qlbanner.hbs
@@ -100,6 +100,7 @@
   <div class="modal-dialog">
     <div class="modal-content">
       <form id="bannerForm" enctype="multipart/form-data">
+        <input type="hidden" id="bannerId">
         <div class="modal-header">
           <h5 class="modal-title" id="addBannerModalLabel">Thêm Banner</h5>
           <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Đóng"></button>
@@ -114,6 +115,7 @@
             <label for="bannerFile" class="form-label">Chọn hình <span class="text-danger">*</span></label>
             <input type="file" id="bannerFile" class="form-control" accept="image/*" required>
             <div class="form-text">Hỗ trợ: JPG, PNG, GIF. Tối đa 5MB</div>
+            <img id="previewCurrent" src="" class="img-thumbnail mt-2 d-none" style="max-height: 150px;">
             <div class="error-message" id="fileError"></div>
           </div>
           <div class="mb-3">


### PR DESCRIPTION
## Summary
- add routes and controller methods for updating banners
- extend admin UI to edit banners with preview
- update banner JS to handle add and edit logic

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_686e428d40c083318e39ca84380a3c2f

## Summary by Sourcery

Add banner editing capability by extending backend APIs and admin UI to support fetching and updating banners in a unified form

New Features:
- Introduce GET /banners/:id and PUT /banners/:id routes with corresponding controller methods to retrieve and update banners
- Enable admin users to open a modal pre-populated with existing banner details and preview current image for editing

Enhancements:
- Refactor BannerManager JavaScript to handle both create and edit workflows in a single submit handler and dynamically toggle validation
- Add an “Edit” button to banner cards and reset modal state (fields, labels, preview) on close