### PR TITLE
Add variant editing support

### DIFF
--- a/controllers/productCtrl.js
+++ b/controllers/productCtrl.js
@@ -9,16 +9,27 @@ exports.createProduct = async (req, res) => {
     const {
       name, category_id, brand_id,
       price, description = '',
-      stock = 0, specifications = []
+      stock = 0, specifications = [],
+      variants = '{}'
     } = req.body;
 
     if (!Array.isArray(specifications)) {
       return res.status(400).json({ error: 'specifications phải là mảng' });
     }
 
+    let parsedVariants = {};
+    if (variants) {
+      try {
+        parsedVariants = JSON.parse(variants);
+      } catch (e) {
+        return res.status(400).json({ error: 'variants phải là JSON hợp lệ' });
+      }
+    }
+
     const newItem = new Product({
       name, category_id, brand_id,
-      price, description, stock, specifications
+      price, description, stock, specifications,
+      variants: parsedVariants
     });
     await newItem.save();
 
@@ -42,16 +53,27 @@ exports.updateProduct = async (req, res) => {
     const {
       name, category_id, brand_id,
       price, description = '',
-      stock = 0, specifications = []
+      stock = 0, specifications = [],
+      variants = '{}'
     } = req.body;
 
     if (!Array.isArray(specifications)) {
       return res.status(400).json({ error: 'specifications phải là mảng' });
     }
 
+    let parsedVariants = {};
+    if (variants) {
+      try {
+        parsedVariants = JSON.parse(variants);
+      } catch (e) {
+        return res.status(400).json({ error: 'variants phải là JSON hợp lệ' });
+      }
+    }
+
     const updates = {
       name, category_id, brand_id,
-      price, description, stock, specifications
+      price, description, stock, specifications,
+      variants: parsedVariants
     };
     const updated = await Product.findByIdAndUpdate(
       req.params.id,

--- a/controllers/tsktCtrl.js
+++ b/controllers/tsktCtrl.js
@@ -53,6 +53,25 @@ exports.deleteTskt = async (req, res) => {
     res.status(400).json({ error: err.message });
   }
 };
+
+// Cập nhật template theo ID
+exports.updateTskt = async (req, res) => {
+  try {
+    const { category_id, specs = [], variantOptions = [] } = req.body;
+    const updates = { category_id, specs, variantOptions };
+    const updated = await TsktProduct.findByIdAndUpdate(
+      req.params.id,
+      updates,
+      { new: true, runValidators: true }
+    );
+    if (!updated) {
+      return res.status(404).json({ error: 'Không tìm thấy template' });
+    }
+    res.json(updated);
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+};
 exports.getFilterFieldsByCategory = async (req, res) => {
   try {
     const { category_id } = req.params;

--- a/models/Product.js
+++ b/models/Product.js
@@ -15,7 +15,9 @@ const productSchema = new mongoose.Schema({
   description:    { type: String, default: '' },
   stock:          { type: Number, default: 0, min: 0 },
   image:          { type: Object, default: '' },
-  specifications: { type: [specSchema], default: [] }
+  specifications: { type: [specSchema], default: [] },
+  // Các biến thể của sản phẩm, lưu theo dạng { tenBienThe: [giaTri] }
+  variants:       { type: Map, of: [String], default: {} }
 }, { timestamps: true });
 
 module.exports = mongoose.model('Product', productSchema);

--- a/public/js/product-form.js
+++ b/public/js/product-form.js
@@ -1,0 +1,166 @@
+const apiProduct = '/product';
+const apiTskt    = '/tsktproducts';
+
+async function loadSpecsAndVariants(catId, specContainer, variantsContainer, existingVariants = {}) {
+  specContainer.innerHTML = '';
+  variantsContainer.innerHTML = '';
+  if (!catId) return;
+  try {
+    const res = await fetch(`${apiTskt}/filters/${catId}`);
+    const data = await res.json();
+    const specs = Array.isArray(data.specs) ? data.specs : [];
+    const variantOpts = Array.isArray(data.variantOptions) ? data.variantOptions : [];
+    specs.forEach(name => {
+      const div = document.createElement('div');
+      div.className = 'spec-item';
+      div.innerHTML = `<label>${name}</label><input type="text" name="specs[${name}]" placeholder="Nhập ${name}" />`;
+      specContainer.appendChild(div);
+    });
+    renderVariantOptions(variantOpts, variantsContainer, existingVariants);
+  } catch (err) {
+    console.error('Load specs/variants error:', err);
+  }
+}
+
+function renderVariantOptions(list, container, existing) {
+  container.innerHTML = '';
+  list.forEach(opt => {
+    const div = document.createElement('div');
+    div.className = 'spec-item';
+    const label = document.createElement('label');
+    label.textContent = opt.name;
+    const select = document.createElement('select');
+    select.multiple = true;
+    select.className = 'form-select';
+    select.dataset.name = opt.name;
+    (opt.options || []).forEach(val => {
+      const o = document.createElement('option');
+      o.value = val;
+      o.textContent = val;
+      if (existing && Array.isArray(existing[opt.name]) && existing[opt.name].includes(val)) {
+        o.selected = true;
+      }
+      select.appendChild(o);
+    });
+    div.appendChild(label);
+    div.appendChild(select);
+    container.appendChild(div);
+  });
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  const form           = document.getElementById('productForm');
+  if (!form) return;
+  const categorySelect = document.getElementById('categorySelect');
+  const specContainer  = document.getElementById('specContainer');
+  const variantsContainer = document.getElementById('variantsContainer');
+  const variantsInput     = document.getElementById('variantsInput');
+  const descInput      = document.getElementById('descriptionInput');
+  const descEditorEl   = document.getElementById('descriptionEditor');
+  const imageFile      = document.getElementById('imageFile');
+  const imagePreview   = document.getElementById('imagePreview');
+  const imageUrlInput  = document.getElementById('imageUrl');
+  let quill;
+  quill = new Quill(descEditorEl, { theme: 'snow' });
+
+  if (imageFile) {
+    imageFile.addEventListener('change', () => {
+      const file = imageFile.files[0];
+      if (file) {
+        imagePreview.src = URL.createObjectURL(file);
+        imagePreview.style.display = '';
+      }
+    });
+  }
+
+  async function preload(id) {
+    try {
+      const res = await fetch(`${apiProduct}/${id}`);
+      const prod = await res.json();
+      form.querySelector('input[name="name"]').value  = prod.name;
+      form.querySelector('input[name="price"]').value = prod.price;
+      form.querySelector('input[name="stock"]').value = prod.stock;
+      quill.root.innerHTML = prod.description || '';
+      if (imagePreview) {
+        imagePreview.src = prod.image || '';
+        imagePreview.style.display = prod.image ? '' : 'none';
+      }
+      if (imageUrlInput) imageUrlInput.value = prod.image || '';
+      categorySelect.value = prod.category_id._id;
+      await loadSpecsAndVariants(prod.category_id._id, specContainer, variantsContainer, prod.variants || {});
+      prod.specifications.forEach(spec => {
+        const input = Array.from(specContainer.querySelectorAll('.spec-item input')).find(inp => inp.previousElementSibling.textContent === spec.key);
+        if (input) input.value = spec.value;
+      });
+    } catch (err) {
+      console.error('Preload product error:', err);
+    }
+  }
+
+  categorySelect.addEventListener('change', () => {
+    loadSpecsAndVariants(categorySelect.value, specContainer, variantsContainer);
+  });
+
+  if (form.dataset.mode === 'edit') {
+    preload(form.dataset.id);
+  } else if (categorySelect.value) {
+    loadSpecsAndVariants(categorySelect.value, specContainer, variantsContainer);
+  }
+
+  form.addEventListener('submit', async e => {
+    e.preventDefault();
+    descInput.value = quill.root.innerHTML;
+
+    const variantData = {};
+    variantsContainer.querySelectorAll('select').forEach(sel => {
+      const name = sel.dataset.name;
+      const vals = Array.from(sel.selectedOptions).map(o => o.value);
+      if (vals.length) variantData[name] = vals;
+    });
+    variantsInput.value = JSON.stringify(variantData);
+
+    const fd = new FormData(form);
+    let imageUrl = imageUrlInput ? imageUrlInput.value : '';
+    if (imageFile && imageFile.files[0]) {
+      const fdImg = new FormData();
+      fdImg.append('image', imageFile.files[0]);
+      try {
+        const upRes = await fetch(`${apiProduct}/upload`, {
+          method: 'POST',
+          body: fdImg
+        });
+        if (upRes.ok) {
+          const data = await upRes.json();
+          imageUrl = data.url;
+        }
+      } catch (err) {
+        console.error('Upload image error:', err);
+      }
+    }
+
+    const payload = {
+      name        : fd.get('name'),
+      category_id : fd.get('category_id'),
+      brand_id    : fd.get('brand_id'),
+      price       : parseFloat(fd.get('price')),
+      stock       : parseInt(fd.get('stock')),
+      image       : imageUrl,
+      description : fd.get('description'),
+      specifications: Array.from(specContainer.querySelectorAll('.spec-item input')).map(inp => ({ key: inp.previousElementSibling.textContent, value: inp.value })),
+      variants: variantsInput.value
+    };
+    const url = fd.get('id') ? `${apiProduct}/${fd.get('id')}` : apiProduct;
+    const method = fd.get('id') ? 'PUT' : 'POST';
+    try {
+      const res = await fetch(url, {
+        method,
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload)
+      });
+      if (!res.ok) throw new Error(`Save failed (${res.status})`);
+      window.location.href = '/admin/products';
+    } catch (err) {
+      console.error('Save product error:', err);
+    }
+  });
+});

--- a/routes/tsktproducts.js
+++ b/routes/tsktproducts.js
@@ -6,6 +6,7 @@ router.post('/', ctrl.createTskt);
 router.post('/bulk', ctrl.createTsktBulk);
 router.get('/category/:category_id', ctrl.getByCategory);
 router.delete('/:id', ctrl.deleteTskt);
+router.put('/:id', ctrl.updateTskt);
 router.get('/filters/:category_id', ctrl.getFilterFieldsByCategory);
 
 module.exports = router;


### PR DESCRIPTION
## Summary
- handle variants in Product model and CRUD controller
- enable updating TsktProduct templates
- expose PUT route for tsktproducts
- implement client-side script for editing product variants

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_b_687dad8a3d44832c822d561aa568a014

## Summary by Sourcery

Enable end-to-end support for editing product variants by extending the Product model and controllers, adding a TsktProduct update route, and integrating variant UI logic on the client side

New Features:
- Add variant field to Product schema and enable parsing and saving variants in product create and update endpoints
- Expose PUT /tsktproducts/:id endpoint with updateTskt controller for updating TsktProduct templates
- Implement client-side script in product-form.js to load, render, and submit product variant options

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for managing product variants, allowing users to specify and edit variant options for each product.
  * Product forms now dynamically load and display specifications and variant options based on the selected category.
  * Enhanced product editing to preload and display existing variants and specifications.
  * Introduced the ability to update template specifications and variant options for products.

* **Bug Fixes**
  * Improved error handling for invalid variant data during product creation and updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->