### PR TITLE
Fix product form fields and variant editing

### DIFF
--- a/controllers/productCtrl.js
+++ b/controllers/productCtrl.js
@@ -163,8 +163,8 @@ exports.getProductById = async (req, res) => {
     let tskt = [];
     if (item.category_id?._id) {
       const tpl = await TsktProduct.findOne({ category_id: item.category_id._id }).lean();
-      if (tpl?.value && Array.isArray(tpl.value)) {
-        tskt = tpl.value.map(key => {
+      if (tpl?.specs && Array.isArray(tpl.specs)) {
+        tskt = tpl.specs.map(key => {
           const spec = Array.isArray(item.specifications)
             ? item.specifications.find(s => s.key === key)
             : null;

--- a/controllers/tsktCtrl.js
+++ b/controllers/tsktCtrl.js
@@ -1,13 +1,13 @@
 const TsktProduct = require('../models/TsktProduct');
 
-// Tạo template đơn lẻ (value là array)
+// Tạo template đơn lẻ
 exports.createTskt = async (req, res) => {
   try {
-    const { category_id, value,variantOptions } = req.body;
-    if (!Array.isArray(value)) {
-      return res.status(400).json({ error: 'value phải là mảng chuỗi' });
+    const { category_id, specs = [], variantOptions = [] } = req.body;
+    if (!Array.isArray(specs)) {
+      return res.status(400).json({ error: 'specs phải là mảng chuỗi' });
     }
-    const item = new TsktProduct({ category_id, value,variantOptions });
+    const item = new TsktProduct({ category_id, specs, variantOptions });
     await item.save();
     res.status(201).json(item);
   } catch (err) {
@@ -18,13 +18,13 @@ exports.createTskt = async (req, res) => {
 // Bulk tạo template nhiều mục
 exports.createTsktBulk = async (req, res) => {
   try {
-    const items = req.body; // mong đợi mảng [{ category_id, value: [String] }, ...]
+    const items = req.body; // mong đợi mảng [{ category_id, specs: [String] }, ...]
     if (!Array.isArray(items)) {
-      return res.status(400).json({ error: 'Body phải là mảng các đối tượng {category_id, value: [String]}' });
+      return res.status(400).json({ error: 'Body phải là mảng các đối tượng {category_id, specs: [String]}' });
     }
     items.forEach(it => {
-      if (!Array.isArray(it.value)) {
-        throw new Error('Mỗi mục phải có value là mảng chuỗi');
+      if (!Array.isArray(it.specs)) {
+        throw new Error('Mỗi mục phải có specs là mảng chuỗi');
       }
     });
     const docs = await TsktProduct.insertMany(items);
@@ -77,14 +77,14 @@ exports.getFilterFieldsByCategory = async (req, res) => {
     const { category_id } = req.params;
     const template = await TsktProduct.findOne({ category_id }).lean();
 
-    if (!template || !Array.isArray(template.value)) {
-      return res.json({ fields: [] });
+    if (!template || !Array.isArray(template.specs)) {
+      return res.json({ specs: [], variantOptions: [] });
     }
 
     res.json({
-  specs: template.specs,
-  variantOptions: template.variantOptions
-}); // trả về mảng ["socket", "core", "thread", ...]
+      specs: template.specs,
+      variantOptions: template.variantOptions
+    });
   } catch (err) {
     res.status(500).json({ error: err.message });
   }

--- a/public/js/product-form.js
+++ b/public/js/product-form.js
@@ -1,5 +1,6 @@
 const apiProduct = '/product';
 const apiTskt    = '/tsktproducts';
+let variantsContainer;
 
 async function loadSpecsAndVariants(catId, specContainer, variantsContainer, existingVariants = {}) {
   specContainer.innerHTML = '';
@@ -24,6 +25,7 @@ async function loadSpecsAndVariants(catId, specContainer, variantsContainer, exi
 
 function renderVariantOptions(list, container, existing) {
   container.innerHTML = '';
+  const used = new Set();
   list.forEach(opt => {
     const div = document.createElement('div');
     div.className = 'spec-item';
@@ -45,7 +47,27 @@ function renderVariantOptions(list, container, existing) {
     div.appendChild(label);
     div.appendChild(select);
     container.appendChild(div);
+    used.add(opt.name);
   });
+
+  // render existing variants that are not in template as custom rows
+  if (existing) {
+    Object.keys(existing).forEach(k => {
+      if (!used.has(k)) {
+        addCustomVariantRow(k, existing[k].join(', '));
+      }
+    });
+  }
+}
+
+function addCustomVariantRow(name = '', values = '') {
+  const div = document.createElement('div');
+  div.className = 'spec-item variant-custom';
+  div.innerHTML = `<input type="text" class="form-control variant-name" placeholder="Tên biến thể" value="${name}">
+                    <input type="text" class="form-control variant-values" placeholder="Giá trị (cách nhau bằng dấu phẩy)" value="${values}">
+                    <button type="button" class="btn btn-sm btn-danger remove-variant"><i class="fas fa-times"></i></button>`;
+  div.querySelector('.remove-variant').addEventListener('click', () => div.remove());
+  variantsContainer.appendChild(div);
 }
 
 document.addEventListener('DOMContentLoaded', () => {
@@ -53,8 +75,9 @@ document.addEventListener('DOMContentLoaded', () => {
   if (!form) return;
   const categorySelect = document.getElementById('categorySelect');
   const specContainer  = document.getElementById('specContainer');
-  const variantsContainer = document.getElementById('variantsContainer');
+  variantsContainer = document.getElementById('variantsContainer');
   const variantsInput     = document.getElementById('variantsInput');
+  const addVariantBtn = document.getElementById('addVariantBtn');
   const descInput      = document.getElementById('descriptionInput');
   const descEditorEl   = document.getElementById('descriptionEditor');
   const imageFile      = document.getElementById('imageFile');
@@ -62,6 +85,10 @@ document.addEventListener('DOMContentLoaded', () => {
   const imageUrlInput  = document.getElementById('imageUrl');
   let quill;
   quill = new Quill(descEditorEl, { theme: 'snow' });
+
+  if (addVariantBtn) {
+    addVariantBtn.addEventListener('click', () => addCustomVariantRow());
+  }
 
   if (imageFile) {
     imageFile.addEventListener('change', () => {
@@ -116,6 +143,11 @@ document.addEventListener('DOMContentLoaded', () => {
       const name = sel.dataset.name;
       const vals = Array.from(sel.selectedOptions).map(o => o.value);
       if (vals.length) variantData[name] = vals;
+    });
+    variantsContainer.querySelectorAll('.variant-custom').forEach(div => {
+      const name = div.querySelector('.variant-name').value.trim();
+      const vals = div.querySelector('.variant-values').value.split(',').map(v => v.trim()).filter(v => v);
+      if (name && vals.length) variantData[name] = vals;
     });
     variantsInput.value = JSON.stringify(variantData);
 

--- a/views/admin/form.hbs
+++ b/views/admin/form.hbs
@@ -243,7 +243,7 @@
     {{#ifEquals mode 'edit'}}<i class="fas fa-edit"></i> Chỉnh sửa sản phẩm{{else}}<i class="fas fa-plus"></i> Tạo sản
     phẩm{{/ifEquals}}
   </h2>
-  <form id="productForm" data-mode="{{mode}}">
+  <form id="productForm" data-mode="{{mode}}" {{#ifEquals mode 'edit'}}data-id="{{product._id}}"{{/ifEquals}}>
     {{#ifEquals mode 'edit'}}
     <input type="hidden" name="id" value="{{product._id}}">
     {{/ifEquals}}


### PR DESCRIPTION
## Summary
- fix TSKT controller to use `specs` field
- update product controller to read variant specs
- allow editing products to preload ID
- enable adding custom variants in product form

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_687db5bce4b8832ca8a4ab7f6c9fcb0a

## Summary by Sourcery

Use the new 'specs' field for template definitions, improve variant rendering and editing in the product form, and ensure the edit form is preloaded with the correct product ID.

New Features:
- Enable adding and removing custom product variant rows in the product form UI

Enhancements:
- Refactor TsktProduct controllers and API to use 'specs' instead of 'value' in single create, bulk create, and filter endpoints
- Update product controller to fetch and map variant specs from Tskt templates
- Revamp product-form.js to render variant specs, preload existing variants (including custom ones), and include them in form submissions
- Add data-id attribute to the product form template in edit mode for proper ID preloading

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced product form to support adding and managing custom variant options directly in the interface.

* **Bug Fixes**
  * Improved handling of technical specifications and variant options for products, ensuring more consistent data structure and validation.

* **Refactor**
  * Updated terminology and data handling from "value" to "specs" for technical specification templates and related operations.
  * Adjusted API responses and input expectations to reflect new "specs" structure.

* **Style**
  * Product form now conditionally includes a data attribute for product ID in edit mode for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->