### PR TITLE
Fix specs not loading on product form

### DIFF
--- a/public/admin/static/js/admin.js
+++ b/public/admin/static/js/admin.js
@@ -134,19 +134,19 @@ async function initProductForm() {
     if (hiddenId) form.dataset.id = hiddenId.value;
   }
 
-  // Load specs when category changes
+  // Load specs when category changes (legacy support)
   categorySelect.addEventListener("change", async () => {
     const catId = categorySelect.value;
     specContainer.innerHTML = "";
     if (!catId) return;
     try {
-      const res  = await fetch(`${apiTskt}/category/${catId}`);
+      const res  = await fetch(`${apiTskt}/filters/${catId}`);
       const data = await res.json();
-      const specs = (data[0] && data[0].value) || [];
+      const specs = Array.isArray(data.specs) ? data.specs : [];
       specs.forEach(fieldName => {
         const div = document.createElement("div");
-        div.className   = "spec-item";
-        div.innerHTML   = `<label>${fieldName}</label><input type="text" name="specs[${fieldName}]" placeholder="Nhập ${fieldName}" />`;
+        div.className = "spec-item";
+        div.innerHTML = `<label>${fieldName}</label><input type="text" name="specs[${fieldName}]" placeholder="Nhập ${fieldName}" />`;
         specContainer.appendChild(div);
       });
     } catch (err) {
@@ -354,7 +354,9 @@ document.addEventListener("DOMContentLoaded", () => {
   // Categories
   if (document.getElementById("categoryTable")) fetchCategories();
   // Forms
-  initProductForm();
+  if (typeof loadSpecsAndVariants !== 'function') {
+    initProductForm();
+  }
   initCategoryForm();
 
   // Responsive menu: Hiện/ẩn nav khi bấm nút 3 sọc


### PR DESCRIPTION
## Summary
- ensure admin.js requests the correct specs API
- avoid duplicate product form initialization when product-form.js is present

## Testing
- `npm test` *(fails: Missing script)*
- `npm start` *(fails: Stripe key missing)*

------
https://chatgpt.com/codex/tasks/task_b_687dc0487474832c8eab1497bcffaf84

## Summary by Sourcery

Fix specs loading on product form by updating API endpoint and response parsing, and prevent duplicate form initialization when product-form.js is present.

Bug Fixes:
- Update specs fetch URL from `/category/{id}` to `/filters/{id}` in admin.js
- Parse specs from `data.specs` array instead of legacy data structure
- Wrap initProductForm call to avoid duplicate initialization when product-form.js is loaded

Enhancements:
- Annotate specs change listener as legacy support
- Clean up minor code formatting in specs rendering

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility with legacy endpoints when fetching product specifications in the admin panel.
  * Enhanced reliability when displaying specification fields for selected categories.

* **Chores**
  * Adjusted initialization logic to prevent duplicate loading of product form features.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->