### PR TITLE
Fix specs not loading on product form

### DIFF
--- a/public/admin/static/js/admin.js
+++ b/public/admin/static/js/admin.js
@@ -134,19 +134,26 @@ async function initProductForm() {
     if (hiddenId) form.dataset.id = hiddenId.value;
   }
 
-  // Load specs when category changes
+  // Load specs when category changes (legacy support)
   categorySelect.addEventListener("change", async () => {
     const catId = categorySelect.value;
     specContainer.innerHTML = "";
     if (!catId) return;
     try {
-      const res  = await fetch(`${apiTskt}/category/${catId}`);
+      let res  = await fetch(`${apiTskt}/filters/${catId}`);
+      if (!res.ok) {
+        res = await fetch(`${apiTskt}/category/${catId}`);
+      }
       const data = await res.json();
-      const specs = (data[0] && data[0].value) || [];
+      const specs = Array.isArray(data.specs) ? data.specs : Array.isArray(data[0]?.specs)
+        ? data[0].specs
+        : Array.isArray(data[0]?.value)
+        ? data[0].value
+        : [];
       specs.forEach(fieldName => {
         const div = document.createElement("div");
-        div.className   = "spec-item";
-        div.innerHTML   = `<label>${fieldName}</label><input type="text" name="specs[${fieldName}]" placeholder="Nhập ${fieldName}" />`;
+        div.className = "spec-item";
+        div.innerHTML = `<label>${fieldName}</label><input type="text" name="specs[${fieldName}]" placeholder="Nhập ${fieldName}" />`;
         specContainer.appendChild(div);
       });
     } catch (err) {
@@ -354,7 +361,9 @@ document.addEventListener("DOMContentLoaded", () => {
   // Categories
   if (document.getElementById("categoryTable")) fetchCategories();
   // Forms
-  initProductForm();
+  if (typeof loadSpecsAndVariants !== 'function') {
+    initProductForm();
+  }
   initCategoryForm();
 
   // Responsive menu: Hiện/ẩn nav khi bấm nút 3 sọc

--- a/public/js/product-form.js
+++ b/public/js/product-form.js
@@ -2,15 +2,38 @@ const apiProduct = '/product';
 const apiTskt    = '/tsktproducts';
 let variantsContainer;
 
-async function loadSpecsAndVariants(catId, specContainer, variantsContainer, existingVariants = {}) {
+async function loadSpecsAndVariants(
+  catId,
+  specContainer,
+  variantsContainer,
+  existingVariants = {}
+) {
   specContainer.innerHTML = '';
   variantsContainer.innerHTML = '';
   if (!catId) return;
   try {
-    const res = await fetch(`${apiTskt}/filters/${catId}`);
+    let res = await fetch(`${apiTskt}/filters/${catId}`);
+    if (!res.ok) {
+      // fallback to legacy endpoint
+      res = await fetch(`${apiTskt}/category/${catId}`);
+    }
     const data = await res.json();
-    const specs = Array.isArray(data.specs) ? data.specs : [];
-    const variantOpts = Array.isArray(data.variantOptions) ? data.variantOptions : [];
+    let specs = [];
+    let variantOpts = [];
+    if (Array.isArray(data.specs)) {
+      specs = data.specs;
+      variantOpts = Array.isArray(data.variantOptions) ? data.variantOptions : [];
+    } else if (Array.isArray(data)) {
+      const first = data[0] || {};
+      if (Array.isArray(first.specs)) {
+        specs = first.specs;
+      } else if (Array.isArray(first.value)) {
+        specs = first.value;
+      }
+      if (Array.isArray(first.variantOptions)) {
+        variantOpts = first.variantOptions;
+      }
+    }
     specs.forEach(name => {
       const div = document.createElement('div');
       div.className = 'spec-item';
@@ -77,6 +100,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const specContainer  = document.getElementById('specContainer');
   variantsContainer = document.getElementById('variantsContainer');
   const variantsInput     = document.getElementById('variantsInput');
+  const brandSelect    = document.getElementById('brandSpinner');
   const addVariantBtn = document.getElementById('addVariantBtn');
   const descInput      = document.getElementById('descriptionInput');
   const descEditorEl   = document.getElementById('descriptionEditor');
@@ -127,6 +151,11 @@ document.addEventListener('DOMContentLoaded', () => {
   categorySelect.addEventListener('change', () => {
     loadSpecsAndVariants(categorySelect.value, specContainer, variantsContainer);
   });
+  if (brandSelect) {
+    brandSelect.addEventListener('change', () => {
+      loadSpecsAndVariants(categorySelect.value, specContainer, variantsContainer);
+    });
+  }
 
   if (form.dataset.mode === 'edit') {
     preload(form.dataset.id);


### PR DESCRIPTION
## Summary
- support both new and legacy specs APIs in product and admin scripts
- refresh specs when the brand dropdown changes

## Testing
- `npm test` *(fails: Missing script)*
- `STRIPE_SECRET_KEY=test MONGO_URI=mongodb://localhost/test npm start` *(terminated: environment not configured)*

------
https://chatgpt.com/codex/tasks/task_b_687dc0487474832c8eab1497bcffaf84

## Summary by Sourcery

Add backward compatibility for specs API endpoints and response formats in product and admin scripts, and enable specs to refresh on brand changes

New Features:
- Reload product specs and variants when the brand dropdown selection changes

Enhancements:
- Support both new `/tsktproducts/filters` API and fall back to legacy `/tsktproducts/category` endpoint for specs
- Parse both new (`data.specs` and `data.variantOptions`) and legacy (array with `first.specs` or `first.value`) response formats
- Guard admin form initialization by checking for the shared `loadSpecsAndVariants` function before calling `initProductForm`