### PR TITLE
Handle tskt field in product forms

### DIFF
--- a/controllers/productCtrl.js
+++ b/controllers/productCtrl.js
@@ -9,12 +9,16 @@ exports.createProduct = async (req, res) => {
     const {
       name, category_id, brand_id,
       price, description = '',
-      stock = 0, specifications = [],
+      stock = 0,
+      specifications = [],
+      tskt = [],
       variants = '{}'
     } = req.body;
 
-    if (!Array.isArray(specifications)) {
-      return res.status(400).json({ error: 'specifications phải là mảng' });
+    const specArr = Array.isArray(tskt) && tskt.length ? tskt : specifications;
+
+    if (!Array.isArray(specArr)) {
+      return res.status(400).json({ error: 'tskt phải là mảng' });
     }
 
     let parsedVariants = {};
@@ -28,7 +32,8 @@ exports.createProduct = async (req, res) => {
 
     const newItem = new Product({
       name, category_id, brand_id,
-      price, description, stock, specifications,
+      price, description, stock,
+      specifications: specArr,
       variants: parsedVariants
     });
     await newItem.save();
@@ -53,12 +58,16 @@ exports.updateProduct = async (req, res) => {
     const {
       name, category_id, brand_id,
       price, description = '',
-      stock = 0, specifications = [],
+      stock = 0,
+      specifications = [],
+      tskt = [],
       variants = '{}'
     } = req.body;
 
-    if (!Array.isArray(specifications)) {
-      return res.status(400).json({ error: 'specifications phải là mảng' });
+    const specArr = Array.isArray(tskt) && tskt.length ? tskt : specifications;
+
+    if (!Array.isArray(specArr)) {
+      return res.status(400).json({ error: 'tskt phải là mảng' });
     }
 
     let parsedVariants = {};
@@ -72,7 +81,8 @@ exports.updateProduct = async (req, res) => {
 
     const updates = {
       name, category_id, brand_id,
-      price, description, stock, specifications,
+      price, description, stock,
+      specifications: specArr,
       variants: parsedVariants
     };
     const updated = await Product.findByIdAndUpdate(
@@ -377,9 +387,10 @@ exports.uploadProductsFromExcel = async (req, res) => {
         }
 
         let specs = [];
-        if (row.specifications) {
+        const rawSpecs = row.tskt || row.specifications;
+        if (rawSpecs) {
           try {
-            const parsed = JSON.parse(row.specifications);
+            const parsed = typeof rawSpecs === 'string' ? JSON.parse(rawSpecs) : rawSpecs;
             if (Array.isArray(parsed)) specs = parsed;
           } catch (e) {
             errors.push(`Row ${row.name}: Invalid specifications format`);

--- a/public/admin/static/js/admin.js
+++ b/public/admin/static/js/admin.js
@@ -186,9 +186,10 @@ async function initProductForm() {
       await new Promise(r => setTimeout(r, 0));
       categorySelect.dispatchEvent(new Event("change"));
       // fill specs values
-      prod.specifications.forEach(spec => {
+      const specList = Array.isArray(prod.tskt) ? prod.tskt : prod.specifications || [];
+      specList.forEach(spec => {
         const input = Array.from(specContainer.querySelectorAll(".spec-item input")).find(
-          inp => inp.previousElementSibling.textContent === spec.key
+          inp => inp.previousElementSibling.textContent === spec.key || inp.previousElementSibling.textContent === spec.label
         );
         if (input) input.value = spec.value;
       });
@@ -229,7 +230,7 @@ async function initProductForm() {
       stock          : parseInt(fd.get("stock")),
       image          : imageUrl,
       description    : fd.get("description"),
-      specifications : Array.from(form.querySelectorAll(".spec-item input")).map(
+      tskt : Array.from(form.querySelectorAll(".spec-item input")).map(
         inp => ({ key: inp.previousElementSibling.textContent, value: inp.value })
       )
     };

--- a/public/js/product-form.js
+++ b/public/js/product-form.js
@@ -139,8 +139,9 @@ document.addEventListener('DOMContentLoaded', () => {
       if (imageUrlInput) imageUrlInput.value = prod.image || '';
       categorySelect.value = prod.category_id._id;
       await loadSpecsAndVariants(prod.category_id._id, specContainer, variantsContainer, prod.variants || {});
-      prod.specifications.forEach(spec => {
-        const input = Array.from(specContainer.querySelectorAll('.spec-item input')).find(inp => inp.previousElementSibling.textContent === spec.key);
+      const specList = Array.isArray(prod.tskt) ? prod.tskt : prod.specifications || [];
+      specList.forEach(spec => {
+        const input = Array.from(specContainer.querySelectorAll('.spec-item input')).find(inp => inp.previousElementSibling.textContent === spec.key || inp.previousElementSibling.textContent === spec.label);
         if (input) input.value = spec.value;
       });
     } catch (err) {
@@ -207,7 +208,7 @@ document.addEventListener('DOMContentLoaded', () => {
       stock       : parseInt(fd.get('stock')),
       image       : imageUrl,
       description : fd.get('description'),
-      specifications: Array.from(specContainer.querySelectorAll('.spec-item input')).map(inp => ({ key: inp.previousElementSibling.textContent, value: inp.value })),
+      tskt: Array.from(specContainer.querySelectorAll('.spec-item input')).map(inp => ({ key: inp.previousElementSibling.textContent, value: inp.value })),
       variants: variantsInput.value
     };
     const url = fd.get('id') ? `${apiProduct}/${fd.get('id')}` : apiProduct;

--- a/views/admin/form.hbs
+++ b/views/admin/form.hbs
@@ -267,12 +267,21 @@
       <label class="form-label">Thông số kỹ thuật</label>
       <div id="specContainer">
         {{#ifEquals mode 'edit'}}
-        {{#each product.specifications}}
-        <div class="spec-item">
-          <label>{{key}}</label>
-          <input type="text" name="specifications[{{key}}]" value="{{value}}">
-        </div>
-        {{/each}}
+        {{#if product.tskt}}
+          {{#each product.tskt}}
+          <div class="spec-item">
+            <label>{{#if key}}{{key}}{{else}}{{label}}{{/if}}</label>
+            <input type="text" name="specs[{{#if key}}{{key}}{{else}}{{label}}{{/if}}]" value="{{value}}">
+          </div>
+          {{/each}}
+        {{else}}
+          {{#each product.specifications}}
+          <div class="spec-item">
+            <label>{{key}}</label>
+            <input type="text" name="specs[{{key}}]" value="{{value}}">
+          </div>
+          {{/each}}
+        {{/if}}
         {{/ifEquals}}
       </div>
     </div>


### PR DESCRIPTION
## Summary
- handle optional `tskt` array when creating or updating products
- allow Excel import to parse `tskt` column
- update admin/product forms to read & submit `tskt`
- adjust Handlebars template to populate specs from `tskt`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_687dd5824f40832c91eed5b36084f2f3

## Summary by Sourcery

Add support for the tskt field throughout product APIs, Excel import, and form rendering/submission

Enhancements:
- Handle optional tskt array in product create and update controllers with fallback to existing specifications
- Enable Excel import to read and parse tskt column or fallback to specifications with proper JSON handling
- Update Handlebars templates and client-side scripts in admin and public forms to display and submit tskt specifications

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for a new product specification field, allowing use of either `tskt` or `specifications` when creating, updating, or uploading products.
* **Bug Fixes**
  * Improved handling and validation of product specifications to ensure correct field prioritization and error messaging.
* **Style**
  * Updated form and input field naming for consistency with the new `tskt` field.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->