### PR TITLE
Integrate CKEditor and update admin product page

### DIFF
--- a/public/admin/static/js/admin.js
+++ b/public/admin/static/js/admin.js
@@ -3,10 +3,10 @@
 // Kiểm tra xem các biến đã được khai báo chưa
 if (typeof window.adminConfig === 'undefined') {
   window.adminConfig = {
-    apiProduct: "/product",
-    apiUsers: "/users/all",
-    apiCategory: "/category",
-    apiTskt: "/tsktproducts",
+    apiProduct: "/api/products",
+    apiUsers: "/api/users/all",
+    apiCategory: "/api/categories",
+    apiTskt: "/api/tsktproducts",
     initialized: false
   };
 }
@@ -40,7 +40,10 @@ async function fetchProducts(page = 1, q = productQuery) {
     const res = await fetch(url);
     if (!res.ok) throw new Error(`HTTP error! status: ${res.status}`);
 
-    const { products, hasMore: more } = await res.json();
+    const data = await res.json();
+    const products = data.products || data.items || [];
+    const more = 'hasMore' in data ? data.hasMore
+      : (data.page && data.totalPages ? data.page < data.totalPages : false);
     renderProducts(products, page > 1);
     hasMore = more;
     currentPage = page;
@@ -122,28 +125,24 @@ async function initProductForm() {
   const imageFile = document.getElementById("imageFile");
   const imagePreview = document.getElementById("imagePreview");
   const imageUrlInput = document.getElementById("imageUrl");
+  const imageSourceSelect = document.getElementById("imageSourceSelect");
+  const imageLink = document.getElementById("imageLink");
+  const imageFileGroup = document.getElementById("imageFileGroup");
+  const imageLinkGroup = document.getElementById("imageLinkGroup");
 
-  let quill;
+  let editor;
 
   if (!form || !categorySelect || !specContainer || !descInput || !descEditorEl) {
     console.error('Required form elements not found');
     return;
   }
 
-  // Initialize Quill editor
+  // Initialize CKEditor
   try {
-    quill = new Quill(descEditorEl, {
-      theme: "snow",
-      modules: {
-        toolbar: [
-          ['bold', 'italic', 'underline'],
-          ['link', 'blockquote'],
-          [{ 'list': 'ordered' }, { 'list': 'bullet' }]
-        ]
-      }
-    });
+    editor = await ClassicEditor.create(descEditorEl);
+    if (descInput.value) editor.setData(descInput.value);
   } catch (error) {
-    console.error('Error initializing Quill:', error);
+    console.error('Error initializing CKEditor:', error);
     return;
   }
 
@@ -154,6 +153,28 @@ async function initProductForm() {
       if (file) {
         imagePreview.src = URL.createObjectURL(file);
         imagePreview.style.display = 'block';
+      }
+    });
+  }
+
+  if (imageLink) {
+    imageLink.addEventListener('input', () => {
+      if (imageLink.value) {
+        imagePreview.src = imageLink.value;
+        imagePreview.style.display = 'block';
+      }
+    });
+  }
+
+  if (imageSourceSelect && imageFileGroup && imageLinkGroup) {
+    imageSourceSelect.addEventListener('change', () => {
+      const mode = imageSourceSelect.value;
+      if (mode === 'link') {
+        imageFileGroup.style.display = 'none';
+        imageLinkGroup.style.display = 'block';
+      } else {
+        imageFileGroup.style.display = 'block';
+        imageLinkGroup.style.display = 'none';
       }
     });
   }
@@ -311,13 +332,19 @@ async function initProductForm() {
         form.querySelector('input[name="name"]').value = prod.name || '';
         form.querySelector('input[name="price"]').value = prod.price || '';
         form.querySelector('input[name="stock"]').value = prod.stock || '';
-        quill.root.innerHTML = prod.description || "";
+        if (editor) editor.setData(prod.description || "");
 
         if (imagePreview) {
           imagePreview.src = prod.image || '';
           imagePreview.style.display = prod.image ? 'block' : 'none';
         }
         if (imageUrlInput) imageUrlInput.value = prod.image || '';
+        if (imageLink) imageLink.value = prod.image || '';
+        if (imageSourceSelect && prod.image) {
+          imageSourceSelect.value = 'link';
+          if (imageFileGroup) imageFileGroup.style.display = 'none';
+          if (imageLinkGroup) imageLinkGroup.style.display = 'block';
+        }
 
         if (prod.category_id && prod.category_id._id) {
           categorySelect.value = prod.category_id._id;
@@ -349,14 +376,15 @@ async function initProductForm() {
     e.preventDefault();
 
     try {
-      // Update description from Quill
-      descInput.value = quill.root.innerHTML;
+      // Update description from CKEditor
+      descInput.value = editor.getData();
 
       const fd = new FormData(form);
       let imageUrl = imageUrlInput ? imageUrlInput.value : '';
 
-      // Upload image if file selected
-      if (imageFile && imageFile.files[0]) {
+      if (imageSourceSelect && imageSourceSelect.value === 'link') {
+        imageUrl = imageLink ? imageLink.value.trim() : '';
+      } else if (imageFile && imageFile.files[0]) {
         const fdImg = new FormData();
         fdImg.append('image', imageFile.files[0]);
 

--- a/views/admin/form.hbs
+++ b/views/admin/form.hbs
@@ -2,7 +2,7 @@
   {{#ifEquals mode 'edit'}}Chỉnh sửa sản phẩm{{else}}Tạo sản phẩm{{/ifEquals}}
 {{/inline}}
 <link rel="stylesheet" href="/admin/static/css/form.css">
-<link href="https://cdn.quilljs.com/1.3.6/quill.snow.css" rel="stylesheet">
+<script src="https://cdn.ckeditor.com/ckeditor5/39.0.0/classic/ckeditor.js"></script>
 
 <!-- Toast notification -->
 <div id="toast" class="toast"></div>
@@ -70,7 +70,16 @@
 
     <div class="form-group">
       <label>Ảnh sản phẩm</label>
-      <input type="file" id="imageFile" accept="image/*">
+      <select id="imageSourceSelect">
+        <option value="file">Tải lên file</option>
+        <option value="link">Dùng URL</option>
+      </select>
+      <div id="imageFileGroup">
+        <input type="file" id="imageFile" accept="image/*">
+      </div>
+      <div id="imageLinkGroup" style="display:none;">
+        <input type="text" id="imageLink" placeholder="Dán URL ảnh">
+      </div>
       <img id="imagePreview" src="{{product.image}}" class="h-24 my-2 max-w-full" {{#unless product.image}}style="display:none"{{/unless}} alt="Product preview">
       <input type="hidden" name="image" id="imageUrl" value="{{product.image}}">
     </div>
@@ -91,6 +100,5 @@
 </div>
 
 <!-- Load scripts in correct order -->
-<script src="https://cdn.quilljs.com/1.3.6/quill.js"></script>
 <script src="/admin/static/js/admin.js"></script>
 


### PR DESCRIPTION
## Summary
- switch to new API endpoints in admin JS
- replace Quill with CKEditor for product description
- allow image upload via file or URL
- handle new product API response shape

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_68837e731608832c973a6ee6eddc7735

## Summary by Sourcery

Integrate CKEditor into the admin product form, update API endpoints to the new /api routes, and enhance the image upload interface with file/URL options and dynamic preview handling.

New Features:
- Allow product image uploads via file or URL with a toggleable form UI and live preview

Enhancements:
- Replace Quill editor with CKEditor for editing product descriptions
- Switch admin JS API endpoints to the new /api routes and adapt fetch logic for varied response shapes
- Update the admin form template to load CKEditor and remove Quill assets