### PR TITLE
Handle combo items during checkout

### DIFF
--- a/models/Order.js
+++ b/models/Order.js
@@ -20,6 +20,14 @@ const orderSchema = new mongoose.Schema({
       }
     }
   ],
+  // Danh sách combo trong đơn (nếu có)
+  combos: [
+    {
+      comboId: { type: mongoose.Schema.Types.ObjectId, ref: 'Combo', required: true },
+      quantity: { type: Number, default: 1 },
+      price:    { type: Number, required: true }
+    }
+  ],
   status: {
     type: String,
     enum: [

--- a/routes/orders.js
+++ b/routes/orders.js
@@ -6,6 +6,7 @@ const Order = require('../models/Order');
 const Image = require('../models/Image');
 const Product = require('../models/Product');
 const Cart = require('../models/Cart');
+const Combo = require('../models/Combo');
 
 
 router.get('/status-tabs', (req, res) => {
@@ -22,8 +23,9 @@ router.get('/status-tabs', (req, res) => {
 // 4) Lấy danh sách đơn hàng của user
 router.get('/user/:userId', async (req, res) => {
   try {
-    const orders = await Order.find({ user_id: req.params.userId })
-                              .populate('products.productId');
+  const orders = await Order.find({ user_id: req.params.userId })
+                            .populate('products.productId')
+                            .populate('combos.comboId');
     // Gắn URL ảnh cho từng sản phẩm
     for (const order of orders) {
       for (const item of order.products) {
@@ -43,35 +45,70 @@ router.get('/user/:userId', async (req, res) => {
 router.post('/checkout', async (req, res) => {
   try {
     const { user_id, address, paymentMethod, shippingMethod, voucher } = req.body;
-     const cart = await Cart.findOne({ user_id }).populate('products.productId');
+
+    const cart = await Cart.findOne({ user_id })
+      .populate('products.productId')
+      .populate('products.comboId');
+
     if (!cart || !cart.products.length) {
       return res.status(400).json({ error: 'Giỏ hàng trống' });
     }
 
-    // Tính tổng
+    // Tính tổng và kiểm tra tồn kho
     let totalPrice = 0;
-   for (const item of cart.products) {
-      const prod = item.productId;
-      const itemPrice = prod.price + (item.variant.priceDiff || 0);
-      if (prod.stock < item.quantity) {
-        return res.status(400).json({ error: `Sản phẩm ${prod.name} chỉ còn ${prod.stock}` });
+    const orderProducts = [];
+    const orderCombos = [];
+
+    for (const item of cart.products) {
+      if (item.productId) {
+        const prod = item.productId;
+        const itemPrice = prod.price + (item.variant?.priceDiff || 0);
+        if (prod.stock < item.quantity) {
+          return res.status(400).json({ error: `Sản phẩm ${prod.name} chỉ còn ${prod.stock}` });
+        }
+        totalPrice += itemPrice * item.quantity;
+
+        await Product.updateOne(
+          { _id: prod._id },
+          { $inc: { stock: -item.quantity } }
+        );
+
+        orderProducts.push({
+          productId: prod._id,
+          quantity: item.quantity,
+          variant: item.variant
+        });
+      } else if (item.comboId) {
+        const combo = item.comboId;
+        // Kiểm tra tồn kho của từng sản phẩm trong combo
+        const comboProducts = await Product.find({ _id: { $in: combo.productIds } });
+        for (const prod of comboProducts) {
+          if (prod.stock < item.quantity) {
+            return res.status(400).json({ error: `Sản phẩm ${prod.name} trong combo chỉ còn ${prod.stock}` });
+          }
+        }
+        // Trừ tồn kho cho từng sản phẩm trong combo
+        for (const prod of comboProducts) {
+          await Product.updateOne(
+            { _id: prod._id },
+            { $inc: { stock: -item.quantity } }
+          );
+        }
+
+        totalPrice += combo.price * item.quantity;
+        orderCombos.push({
+          comboId: combo._id,
+          quantity: item.quantity,
+          price: combo.price
+        });
       }
-      totalPrice += itemPrice * item.quantity;
-      // Giảm stock
-      await Product.updateOne(
-        { _id: prod._id },
-        { $inc: { stock: -item.quantity } }
-      );
     }
 
-    // Cập nhật đơn
+    // Tạo đơn hàng
     const order = new Order({
       user_id,
-      products: cart.products.map(p => ({
-        productId: p.productId._id || p.productId,
-        quantity: p.quantity,
-        variant: p.variant
-      })),
+      products: orderProducts,
+      combos: orderCombos,
       address,
       paymentMethod,
       shippingMethod,
@@ -81,8 +118,43 @@ router.post('/checkout', async (req, res) => {
       status: 'pending'
     });
     await order.save();
+
+    // Xóa giỏ hàng
     cart.products = [];
     await cart.save();
+
+    // Tự động hủy sau 20 phút nếu chưa thanh toán
+    setTimeout(async () => {
+      try {
+        const check = await Order.findById(order._id);
+        if (check && check.status === 'pending') {
+          // Hoàn lại tồn kho
+          for (const p of check.products) {
+            await Product.updateOne(
+              { _id: p.productId },
+              { $inc: { stock: p.quantity } }
+            );
+          }
+          for (const c of check.combos) {
+            const combo = await Combo.findById(c.comboId);
+            if (combo) {
+              for (const pid of combo.productIds) {
+                await Product.updateOne(
+                  { _id: pid },
+                  { $inc: { stock: c.quantity } }
+                );
+              }
+            }
+          }
+          check.status = 'cancelled';
+          check.cancelledAt = new Date();
+          await check.save();
+        }
+      } catch (e) {
+        console.error('Auto cancel order error:', e);
+      }
+    }, 20 * 60 * 1000);
+
     res.status(200).json({ message: 'Đặt hàng thành công', orderId: order._id });
   } catch (err) {
     console.error(err);
@@ -95,8 +167,9 @@ router.post('/checkout', async (req, res) => {
 router.get('/:id', async (req, res) => {
   try {
     const order = await Order.findById(req.params.id)
-      .populate('user_id', 'full_name')           
+      .populate('user_id', 'full_name')
       .populate('products.productId', 'name price image')
+      .populate('combos.comboId')
       .lean();
     return res.json(order);
 
@@ -115,7 +188,9 @@ router.put('/:id', async (req, res) => {
       req.params.id,
       req.body,
       { new: true }
-    ).populate('products.productId');
+    )
+      .populate('products.productId')
+      .populate('combos.comboId');
     
     if (!updated) {
       return res.status(404).json({ error: 'Không tìm thấy đơn hàng' });
@@ -146,6 +221,7 @@ router.get('/', async (req, res) => {
 
     let orders = await Order.find(filter)
       .populate('products.productId')
+      .populate('combos.comboId')
       .populate('user_id', 'full_name')
       .sort({ createdAt: -1 })
       .skip(skip)
@@ -175,6 +251,7 @@ router.get('/:id', async (req, res) => {
   try {
     const order = await Order.findById(req.params.id)
       .populate('products.productId')
+      .populate('combos.comboId')
       .populate('user_id', 'full_name email');
     if (!order) return res.status(404).json({ error: 'Không tìm thấy đơn hàng' });
     res.json(order);


### PR DESCRIPTION
## Summary
- support combo items in orders by adding a `combos` field on the order schema
- update order listing APIs so combos are populated
- fix `/orders/checkout` to process combo items, reduce stock and schedule auto-cancel after 20 minutes

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_68839e08aae8832caff869b5be0ce0cd