### PR TITLE
Wire up forgot password API

### DIFF
--- a/app.js
+++ b/app.js
@@ -35,6 +35,7 @@ var comboRoutes = require('./routes/comboRoutes');
 var videoRoutes = require('./routes/videoRoutes');
 var pcbuilderRouter = require('./routes/pcbuilder');
 var resetPasswordRoutes = require("./routes/resetPassword.route");
+var authRoutes = require("./routes/auth.route");
 var { default: mongoose } = require('mongoose');
 var cors = require('cors');
 
@@ -90,6 +91,7 @@ app.get('/admin', (req, res) => {
 });
 
 app.use("/", resetPasswordRoutes);
+app.use("/", authRoutes);
 app.use('/stripe', stripeRouter);
 app.use('/sepay', sepayRouter);
 app.use('/admin', adminRouter);

--- a/controllers/authController.js
+++ b/controllers/authController.js
@@ -1,36 +1,54 @@
 const crypto = require("crypto");
-const User = require("../models/User");
+const User = require("../models/userModel");
 const ResetToken = require("../models/ResetToken");
 const sendEmail = require("../utils/sendEmail");
 
 exports.forgotPassword = async (req, res) => {
-  const { email } = req.body;
+  try {
+    const { email } = req.body;
 
-  if (!email) return res.status(400).json({ message: "Email là bắt buộc." });
+    if (!email) {
+      return res.status(400).json({ message: "Email là bắt buộc." });
+    }
 
-  const user = await User.findOne({ email });
-  if (!user) return res.status(404).json({ message: "Không tìm thấy người dùng." });
+    const user = await User.findOne({ email });
+    if (!user) {
+      return res
+        .status(404)
+        .json({ message: "Không tìm thấy người dùng." });
+    }
 
-  const token = crypto.randomBytes(32).toString("hex");
-  const hashedToken = crypto.createHash("sha256").update(token).digest("hex");
+    const token = crypto.randomBytes(32).toString("hex");
+    const hashedToken = crypto
+      .createHash("sha256")
+      .update(token)
+      .digest("hex");
 
-  await ResetToken.findOneAndDelete({ userId: user._id });
+    await ResetToken.findOneAndDelete({ userId: user._id });
 
-  const resetToken = new ResetToken({
-    userId: user._id,
-    token: hashedToken,
-    expiresAt: Date.now() + 15 * 60 * 1000,
-  });
+    const resetToken = new ResetToken({
+      userId: user._id,
+      token: hashedToken,
+      expiresAt: Date.now() + 15 * 60 * 1000,
+    });
 
-  await resetToken.save();
+    await resetToken.save();
 
-  const resetLink = `http://yourdomain.com/reset-password?token=${token}&id=${user._id}`;
+    const resetLink = `http://yourdomain.com/reset-password?token=${token}&id=${user._id}`;
 
-  await sendEmail(user.email, "Đặt lại mật khẩu", `
-    Nhấn vào link sau để đặt lại mật khẩu:
-    ${resetLink}
-    Link này có hiệu lực trong 15 phút.
-  `);
+    await sendEmail(
+      user.email,
+      "Đặt lại mật khẩu",
+      `Nhấn vào link sau để đặt lại mật khẩu:\n${resetLink}\nLink này có hiệu lực trong 15 phút.`
+    );
 
-  res.status(200).json({ message: "Email đặt lại mật khẩu đã được gửi." });
+    res
+      .status(200)
+      .json({ message: "Email đặt lại mật khẩu đã được gửi." });
+  } catch (error) {
+    console.error("forgotPassword error:", error);
+    res
+      .status(500)
+      .json({ message: "Đã xảy ra lỗi, vui lòng thử lại sau." });
+  }
 };

--- a/controllers/resetPassword.controller.js
+++ b/controllers/resetPassword.controller.js
@@ -1,6 +1,6 @@
 const crypto = require("crypto");
-const ResetToken = require("../models/resetToken.model");
-const User = require("../models/user.model");
+const ResetToken = require("../models/ResetToken");
+const User = require("../models/userModel");
 
 exports.renderForm = (req, res) => {
   const { token, id: userId } = req.query;

--- a/models/userModel.js
+++ b/models/userModel.js
@@ -1,5 +1,6 @@
 // models/User.js
 const mongoose = require('mongoose');
+const bcrypt = require('bcrypt');
 
 const userSchema = new mongoose.Schema({
   full_name: {

--- a/routes/auth.route.js
+++ b/routes/auth.route.js
@@ -1,0 +1,8 @@
+const express = require("express");
+const router = express.Router();
+const { forgotPassword } = require("../controllers/authController");
+const { forgotPasswordLimiter } = require("../middlewares/rateLimiter");
+
+router.post("/forgot-password", forgotPasswordLimiter, forgotPassword);
+
+module.exports = router;


### PR DESCRIPTION
## Summary
- add POST /forgot-password route and integrate rate limiting
- fix model imports and add error handling for password reset
- ensure user schema hashes passwords correctly with bcrypt

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_b_688f8585e77c832cae3f0ddea58adaa2

## Summary by Sourcery

Wire up the forgot password flow by exposing a rate-limited endpoint, generating and storing secure reset tokens, sending reset emails, and ensuring passwords are hashed properly.

New Features:
- Expose POST /forgot-password endpoint with integrated rate limiting
- Generate, hash, and persist password reset tokens and send reset emails

Enhancements:
- Wrap forgot password logic in error handling for robust API responses
- Standardize model import paths and fix naming inconsistencies
- Integrate bcrypt in user schema to hash passwords automatically