### PR TITLE
fix: ensure banner modals overlay page

### DIFF
--- a/public/admin/static/js/banner.js
+++ b/public/admin/static/js/banner.js
@@ -8,8 +8,18 @@ const BannerManager = {
 
   // Initialize: tải banner và gắn event
   init() {
+    // Đưa các modal ra ngoài phần tử có transform để modal hiển thị chính xác
+    this.moveModalsToBody();
     this.loadBanners();
     this.setupEventListeners();
+  },
+
+  // Di chuyển modal tới body để tránh bị ảnh hưởng bởi transform/position của phần tử cha
+  moveModalsToBody() {
+    ['addBannerModal', 'bannerPreviewModal'].forEach(id => {
+      const el = document.getElementById(id);
+      if (el) document.body.appendChild(el);
+    });
   },
 
   // Nếu là URL đầy đủ trả về nguyên, ngược lại prepend "/"


### PR DESCRIPTION
## Summary
- move banner modals to document body so they are not constrained by parent transforms
- initialize modals before loading banners and attaching listeners

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_b_68963d9d20c0832cb40fbb3de049aa49

## Summary by Sourcery

Move banner modals to the document body and initialize them early so they display correctly above transformed parent elements

Bug Fixes:
- Ensure banner modals overlay the page by appending them to document.body

Enhancements:
- Initialize modals before loading banners and attaching event listeners