### PR TITLE
fix: ensure banner modals overlay page

### DIFF
--- a/public/admin/static/js/banner.js
+++ b/public/admin/static/js/banner.js
@@ -8,8 +8,18 @@ const BannerManager = {
 
   // Initialize: tải banner và gắn event
   init() {
+    // Đưa các modal ra ngoài phần tử có transform để modal hiển thị chính xác
+    this.moveModalsToBody();
     this.loadBanners();
     this.setupEventListeners();
+  },
+
+  // Di chuyển modal tới body để tránh bị ảnh hưởng bởi transform/position của phần tử cha
+  moveModalsToBody() {
+    ['addBannerModal', 'bannerPreviewModal'].forEach(id => {
+      const el = document.getElementById(id);
+      if (el) document.body.appendChild(el);
+    });
   },
 
   // Nếu là URL đầy đủ trả về nguyên, ngược lại prepend "/"
@@ -33,11 +43,9 @@ const BannerManager = {
   async loadBanners() {
     const container = document.getElementById('bannerList');
     try {
-      console.log('🔄 Đang tải banner từ:', this.BANNER_API);
       const res = await fetch(this.BANNER_API);
       if (!res.ok) throw new Error(`HTTP ${res.status}: ${res.statusText}`);
       const list = await res.json();
-      console.log('📊 Banner data:', list);
 
       if (!Array.isArray(list) || list.length === 0) {
         container.innerHTML = `
@@ -61,7 +69,7 @@ const BannerManager = {
         const createdDate = new Date(banner.createdAt).toLocaleDateString('vi-VN');
 
         col.innerHTML = `
-          <div class="card shadow-sm banner-card" style="border: 2px red">
+          <div class="card shadow-sm banner-card">
             <img src="${fullImageUrl}"
                  class="card-img-top"
                  alt="${title}"

--- a/public/admin/static/js/baocao.js
+++ b/public/admin/static/js/baocao.js
@@ -7,6 +7,9 @@ const fmtCur = (v) =>
 // Khởi tạo AOS và tải dữ liệu ban đầu
 document.addEventListener('DOMContentLoaded', async () => {
   AOS.init({ duration: 800, easing: 'ease-out-cubic', once: true });
+  // Move detail table modal to body so it overlays correctly
+  const tableModal = document.getElementById('tableModal');
+  if (tableModal) document.body.appendChild(tableModal);
 
   const spinner = document.getElementById('loadingSpinner');
   if (spinner) spinner.style.display = 'flex';

--- a/views/admin/order.hbs
+++ b/views/admin/order.hbs
@@ -258,6 +258,11 @@
 </div>
 
     <script>
+        // Move edit modal to body to prevent transform issues
+        const editOrderModalEl = document.getElementById('editOrderModal');
+        if (editOrderModalEl && editOrderModalEl.parentNode !== document.body) {
+            document.body.appendChild(editOrderModalEl);
+        }
         let currentStatus = '';
         let currentOrders = [];
         let isLoading = false;

--- a/views/admin/video-form.hbs
+++ b/views/admin/video-form.hbs
@@ -806,6 +806,11 @@ let selectedProducts = [];
 let uploadedFile = null;
 
 document.addEventListener('DOMContentLoaded', async function() {
+    // Move preview modal outside transformed container
+    const previewModalEl = document.getElementById('previewModal');
+    if (previewModalEl && previewModalEl.parentNode !== document.body) {
+        document.body.appendChild(previewModalEl);
+    }
     setupFileUpload();
     setupFormValidation();
     await loadCombos();


### PR DESCRIPTION
## Summary
- move banner modals to document body so they are not constrained by parent transforms
- initialize modals before loading banners and attaching listeners
- relocate other admin modals (orders, reports, video preview) to the document body
- remove stray debug logs and styles from banner rendering

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_b_68963d9d20c0832cb40fbb3de049aa49

## Summary by Sourcery

Ensure various admin modals (banners, orders, reports, video preview) correctly overlay the page by appending them to document.body, initialize banner modals before loading, and clean up stray debug logs and styles.

Bug Fixes:
- Remove stray console.log debug statements from banner loading
- Remove stray red border style from banner cards

Enhancements:
- Move banner, order, report, and video preview modals to document.body to avoid transform/position constraints
- Initialize modals in BannerManager before loading banners