### PR TITLE
feat: add password reset flow

### DIFF
--- a/models/userModel.js
+++ b/models/userModel.js
@@ -64,6 +64,8 @@ const userSchema = new mongoose.Schema({
     type: Date,
     default: Date.now
   },
+  resetPasswordToken: String,
+  resetPasswordExpires: Date,
   addresses: [
     {
       _id: false,

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "mongoose": "^8.15.0",
         "morgan": "~1.9.1",
         "multer": "^2.0.1",
+        "nodemailer": "^6.10.1",
         "nodemon": "^3.1.10",
         "socket.io": "^4.8.1",
         "stripe": "^18.3.0",
@@ -1605,6 +1606,15 @@
         "node-gyp-build": "bin.js",
         "node-gyp-build-optional": "optional.js",
         "node-gyp-build-test": "build-test.js"
+      }
+    },
+    "node_modules/nodemailer": {
+      "version": "6.10.1",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.10.1.tgz",
+      "integrity": "sha512-Z+iLaBGVaSjbIzQ4pX6XV41HrooLsQ10ZWPUehGmuantvzWoDVBnmsdUcOIDM1t+yPor5pDhVlDESgOMEGxhHA==",
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/nodemon": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "mongoose": "^8.15.0",
     "morgan": "~1.9.1",
     "multer": "^2.0.1",
+    "nodemailer": "^6.10.1",
     "nodemon": "^3.1.10",
     "socket.io": "^4.8.1",
     "stripe": "^18.3.0",

--- a/routes/index.js
+++ b/routes/index.js
@@ -11,4 +11,12 @@ router.get('/login', function (req, res) {
   res.render('login', { title: 'Login' });
 });
 
+router.get('/forgot-password', (req, res) => {
+  res.render('forgot-password', { title: 'Forgot Password' });
+});
+
+router.get('/reset-password/:token', (req, res) => {
+  res.render('reset-password', { token: req.params.token, title: 'Reset Password' });
+});
+
 module.exports = router;

--- a/routes/users.js
+++ b/routes/users.js
@@ -5,6 +5,8 @@ const jwt = require('jsonwebtoken');
 const User = require('../models/userModel');
 const Banner = require('../models/Banner');
 require('dotenv').config();
+const nodemailer = require('nodemailer');
+const crypto = require('crypto');
 
 const fs = require('fs');
 const path = require('path');
@@ -128,6 +130,63 @@ router.post('/login', async (req, res) => {
     });
 
   } catch (err) {
+    res.status(500).json({ message: 'Server error', error: err.message });
+  }
+});
+
+// Forgot password
+router.post('/forgot-password', async (req, res) => {
+  try {
+    const { email } = req.body;
+    const user = await User.findOne({ email });
+    if (!user) {
+      return res.status(404).json({ message: 'User not found' });
+    }
+    const token = crypto.randomBytes(20).toString('hex');
+    user.resetPasswordToken = token;
+    user.resetPasswordExpires = Date.now() + 3600000;
+    await user.save();
+    const resetLink = `${req.protocol}://${req.get('host')}/reset-password/${token}`;
+    const transporter = nodemailer.createTransport({
+      service: 'gmail',
+      auth: {
+        user: process.env.EMAIL_USER,
+        pass: process.env.EMAIL_PASS,
+      },
+    });
+    await transporter.sendMail({
+      to: user.email,
+      from: process.env.EMAIL_USER,
+      subject: 'Đặt lại mật khẩu',
+      text: `Bạn nhận được email này vì đã yêu cầu đặt lại mật khẩu.\n\nVui lòng click vào link sau để đặt lại mật khẩu:\n${resetLink}\n\nNếu bạn không yêu cầu, hãy bỏ qua email này.`,
+    });
+    res.json({ message: 'Email đặt lại mật khẩu đã được gửi' });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ message: 'Server error', error: err.message });
+  }
+});
+
+// Reset password
+router.post('/reset-password/:token', async (req, res) => {
+  try {
+    const user = await User.findOne({
+      resetPasswordToken: req.params.token,
+      resetPasswordExpires: { $gt: Date.now() },
+    });
+    if (!user) {
+      return res
+        .status(400)
+        .json({ message: 'Token không hợp lệ hoặc đã hết hạn' });
+    }
+    const hashed = await bcrypt.hash(req.body.password, 10);
+    user.password = hashed;
+    user.resetPasswordToken = undefined;
+    user.resetPasswordExpires = undefined;
+    await user.save();
+    res.json({ message: 'Đặt lại mật khẩu thành công' });
+  } catch (err) {
+    console.error(err);
     res.status(500).json({ message: 'Server error', error: err.message });
   }
 });

--- a/views/forgot-password.hbs
+++ b/views/forgot-password.hbs
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="vi">
+<head>
+  <meta charset="UTF-8" />
+  <title>Quên mật khẩu</title>
+</head>
+<body>
+  <h1>Quên mật khẩu</h1>
+  <form id="forgotForm">
+    <input type="email" id="email" placeholder="Email" required />
+    <button type="submit">Gửi</button>
+  </form>
+  <div id="message"></div>
+  <script>
+    document.getElementById('forgotForm').addEventListener('submit', async function(e) {
+      e.preventDefault();
+      const res = await fetch('/users/forgot-password', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email: document.getElementById('email').value })
+      });
+      const data = await res.json();
+      document.getElementById('message').innerText = data.message || 'Có lỗi xảy ra';
+    });
+  </script>
+</body>
+</html>

--- a/views/reset-password.hbs
+++ b/views/reset-password.hbs
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="vi">
+<head>
+  <meta charset="UTF-8" />
+  <title>Đặt lại mật khẩu</title>
+</head>
+<body>
+  <h1>Đặt lại mật khẩu</h1>
+  <form id="resetForm">
+    <input type="password" id="password" placeholder="Mật khẩu mới" required />
+    <button type="submit">Đổi mật khẩu</button>
+  </form>
+  <div id="message"></div>
+  <script>
+    document.getElementById('resetForm').addEventListener('submit', async function(e) {
+      e.preventDefault();
+      const res = await fetch('/users/reset-password/{{token}}', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ password: document.getElementById('password').value })
+      });
+      const data = await res.json();
+      document.getElementById('message').innerText = data.message || 'Có lỗi xảy ra';
+    });
+  </script>
+</body>
+</html>

--- a/yarn.lock
+++ b/yarn.lock
@@ -949,6 +949,11 @@ node-gyp-build@^4.8.4:
   resolved "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz"
   integrity sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==
 
+nodemailer@^6.10.1:
+  version "6.10.1"
+  resolved "https://registry.npmjs.org/nodemailer/-/nodemailer-6.10.1.tgz"
+  integrity sha512-Z+iLaBGVaSjbIzQ4pX6XV41HrooLsQ10ZWPUehGmuantvzWoDVBnmsdUcOIDM1t+yPor5pDhVlDESgOMEGxhHA==
+
 nodemon@^3.1.10:
   version "3.1.10"
   resolved "https://registry.npmjs.org/nodemon/-/nodemon-3.1.10.tgz"


### PR DESCRIPTION
## Summary
- allow users to request a password reset via email link
- add handlebars pages for requesting and resetting passwords
- track password reset token and expiry for users

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68966df7cf60833096399af0cfc4e1b2

## Summary by Sourcery

Implement an email-based password reset flow with token generation, expiry tracking, and UI templates

New Features:
- Add endpoints for requesting and resetting passwords via email tokens
- Include Handlebars templates (forgot-password and reset-password) for password reset UI

Enhancements:
- Extend User schema with resetPasswordToken and resetPasswordExpires fields

Build:
- Add nodemailer dependency for sending password reset emails