### PR TITLE
feat: add AI chatbot endpoint

### DIFF
--- a/ai/client.js
+++ b/ai/client.js
@@ -1,0 +1,24 @@
+const { functionDeclarations } = require('./tools');
+
+let cachedModel = null;
+
+async function getGemini() {
+  if (cachedModel) return cachedModel;
+
+  const { GoogleGenerativeAI } = await import('@google/generative-ai');
+  const apiKey = process.env.GEMINI_API_KEY;
+  if (!apiKey) throw new Error('GEMINI_API_KEY missing');
+
+  const genAI = new GoogleGenerativeAI(apiKey);
+  const modelName = process.env.GEMINI_MODEL || 'gemini-1.5-pro';
+
+  cachedModel = genAI.getGenerativeModel({
+    model: modelName,
+    tools: [{ functionDeclarations }],
+  });
+
+  return cachedModel;
+}
+
+module.exports = { getGemini };
+

--- a/ai/tools.js
+++ b/ai/tools.js
@@ -1,0 +1,120 @@
+const Product = require('../models/Product');
+const { searchSchema, skuSchema, regexEscape } = require('../utils/sanitize');
+
+// Tell Gemini what tools exist and what args they take
+const functionDeclarations = [
+  {
+    name: 'searchProducts',
+    description: 'Search products by filters and return a short list.',
+    parameters: {
+      type: 'OBJECT',
+      properties: {
+        q: { type: 'STRING' },
+        category: { type: 'STRING' },
+        priceMin: { type: 'NUMBER' },
+        priceMax: { type: 'NUMBER' },
+        inStock: { type: 'BOOLEAN' },
+        limit: { type: 'INTEGER', minimum: 1, maximum: 20 },
+        page: { type: 'INTEGER', minimum: 1 },
+        sort: { type: 'STRING', enum: ['relevance', 'price_asc', 'price_desc', 'updated_desc'] },
+      },
+    },
+  },
+  {
+    name: 'getProductBySku',
+    description: 'Get a single product by SKU.',
+    parameters: {
+      type: 'OBJECT',
+      properties: { sku: { type: 'STRING' } },
+      required: ['sku'],
+    },
+  },
+];
+
+function buildSort(sort) {
+  switch (sort) {
+    case 'price_asc':
+      return { price: 1 };
+    case 'price_desc':
+      return { price: -1 };
+    case 'updated_desc':
+      return { updatedAt: -1 };
+    default:
+      return undefined; // relevance handled when Atlas Search is used
+  }
+}
+
+async function run_searchProducts(rawArgs) {
+  const args = searchSchema.parse(rawArgs || {});
+  const query = {};
+
+  if (args.category) query.category_id = args.category;
+  if (args.inStock === true) query.stock = { $gt: 0 };
+  if (args.priceMin != null || args.priceMax != null) {
+    query.price = {};
+    if (args.priceMin != null) query.price.$gte = args.priceMin;
+    if (args.priceMax != null) query.price.$lte = args.priceMax;
+  }
+
+  if (args.q) {
+    const safe = regexEscape(args.q);
+    query.$or = [
+      { name: new RegExp(safe, 'i') },
+      { description: new RegExp(safe, 'i') },
+    ];
+  }
+
+  const docs = await Product.find(query)
+    .select('_id name price stock category_id updatedAt')
+    .sort(buildSort(args.sort) ?? { updatedAt: -1 })
+    .skip((args.page - 1) * args.limit)
+    .limit(args.limit)
+    .lean();
+
+  const mapped = docs.map((d) => ({
+    sku: String(d._id),
+    name: d.name,
+    price: d.price,
+    stock: d.stock,
+    category: d.category_id,
+    updatedAt: d.updatedAt,
+  }));
+
+  return { ok: true, data: mapped };
+}
+
+async function run_getProductBySku(rawArgs) {
+  const { sku } = skuSchema.parse(rawArgs || {});
+  const doc = await Product.findById(sku)
+    .select('_id name category_id price stock specifications description updatedAt')
+    .lean();
+  if (!doc) return { ok: false, error: 'NOT_FOUND' };
+
+  return {
+    ok: true,
+    data: {
+      sku: String(doc._id),
+      name: doc.name,
+      category: doc.category_id,
+      price: doc.price,
+      stock: doc.stock,
+      specs: doc.specifications,
+      description: doc.description,
+      updatedAt: doc.updatedAt,
+    },
+  };
+}
+
+async function dispatchTool(name, args) {
+  if (name === 'searchProducts') return run_searchProducts(args);
+  if (name === 'getProductBySku') return run_getProductBySku(args);
+  return { ok: false, error: 'Unknown tool' };
+}
+
+const SYSTEM_PROMPT = `Bạn là trợ lý bán hàng cho cửa hàng điện thoại/phụ kiện.
+- Khi câu hỏi cần giá/tồn kho/chi tiết sản phẩm → gọi tool tương ứng.
+- Không tiết lộ dữ liệu nội bộ (PII, giá nhập, biên lợi nhuận).
+- Trả lời ngắn gọn bằng tiếng Việt, ghi giá VND, kèm SKU khi trích từ DB.`;
+
+module.exports = { functionDeclarations, dispatchTool, SYSTEM_PROMPT };
+

--- a/app.js
+++ b/app.js
@@ -34,6 +34,7 @@ var searchRouter = require('./routes/search');
 var comboRoutes = require('./routes/comboRoutes');
 var videoRoutes = require('./routes/videoRoutes');
 var pcbuilderRouter = require('./routes/pcbuilder');
+var chatRouter = require('./routes/chat');
 const { default: mongoose } = require('mongoose');
 var cors = require('cors');
 
@@ -115,6 +116,7 @@ app.use('/reports', reportRoutes);
 app.use('/notifications', notificationsRouter);
 app.use('/banners', bannerRoutes);
 app.use('/pcbuild', pcbuilderRouter);
+app.use('/ai', chatRouter);
 
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "hipc-sever",
       "version": "0.0.0",
       "dependencies": {
+        "@google/generative-ai": "^0.24.1",
         "axios": "^1.11.0",
         "bcrypt": "^6.0.0",
         "bcryptjs": "^3.0.2",
@@ -28,7 +29,17 @@
         "socket.io": "^4.8.1",
         "stripe": "^18.3.0",
         "vnpay": "^2.4.0",
-        "xlsx": "^0.18.5"
+        "xlsx": "^0.18.5",
+        "zod": "^4.0.17"
+      }
+    },
+    "node_modules/@google/generative-ai": {
+      "version": "0.24.1",
+      "resolved": "https://registry.npmjs.org/@google/generative-ai/-/generative-ai-0.24.1.tgz",
+      "integrity": "sha512-MqO+MLfM6kjxcKoy0p1wRzG3b4ZZXtPI+z2IE26UogS2Cm/XHO+7gGRBh6gcJsOiIVoH93UwKvW4HdgiOZCy9Q==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@mongodb-js/saslprep": {
@@ -2526,6 +2537,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.4"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.0.17",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.0.17.tgz",
+      "integrity": "sha512-1PHjlYRevNxxdy2JZ8JcNAw7rX8V9P1AKkP+x/xZfxB0K5FYfuV+Ug6P/6NVSR2jHQ+FzDDoDHS04nYUsOIyLQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -27,7 +27,9 @@
     "socket.io": "^4.8.1",
     "stripe": "^18.3.0",
     "vnpay": "^2.4.0",
-    "xlsx": "^0.18.5"
+    "xlsx": "^0.18.5",
+    "@google/generative-ai": "^0.24.1",
+    "zod": "^4.0.17"
   },
   "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/routes/chat.js
+++ b/routes/chat.js
@@ -1,0 +1,47 @@
+const express = require('express');
+const router = express.Router();
+const { getGemini } = require('../ai/client');
+const { SYSTEM_PROMPT, dispatchTool } = require('../ai/tools');
+
+router.post('/chat', async (req, res) => {
+  try {
+    const userMsg = String(req.body.message || '').slice(0, 4000);
+    const model = await getGemini();
+
+    // Step 1: ask Gemini; it may decide to call tools
+    const first = await model.generateContent({
+      contents: [
+        { role: 'user', parts: [{ text: SYSTEM_PROMPT }] },
+        { role: 'user', parts: [{ text: userMsg }] },
+      ],
+    });
+
+    const parts = first.response.candidates?.[0]?.content?.parts || [];
+    const calls = parts.filter((p) => p.functionCall);
+
+    // Step 2: execute tool calls (if any)
+    const toolParts = [];
+    for (const p of calls) {
+      const { name, args } = p.functionCall;
+      const result = await dispatchTool(name, args);
+      toolParts.push({ functionResponse: { name, response: result } });
+    }
+
+    // Step 3: give tool results back to Gemini to compose natural reply
+    const final = await model.generateContent({
+      contents: [
+        { role: 'user', parts: [{ text: userMsg }] },
+        ...toolParts.map((tp) => ({ role: 'tool', parts: [tp] })),
+      ],
+    });
+
+    const text = final.response.text();
+    res.json({ reply: text });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'CHAT_ERROR', detail: String(err.message || err) });
+  }
+});
+
+module.exports = router;
+

--- a/utils/sanitize.js
+++ b/utils/sanitize.js
@@ -1,0 +1,24 @@
+const { z } = require('zod');
+
+// Schema for product search filters
+const searchSchema = z.object({
+  q: z.string().trim().min(0).optional(),
+  category: z.string().trim().optional(),
+  priceMin: z.coerce.number().optional(),
+  priceMax: z.coerce.number().optional(),
+  inStock: z.coerce.boolean().optional(),
+  limit: z.coerce.number().int().min(1).max(20).default(5),
+  page: z.coerce.number().int().min(1).default(1),
+  sort: z.enum(["relevance", "price_asc", "price_desc", "updated_desc"]).default("updated_desc"),
+});
+
+// Schema for a single SKU lookup
+const skuSchema = z.object({ sku: z.string().trim().min(1) });
+
+// Escape regex special characters
+function regexEscape(s) {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+module.exports = { searchSchema, skuSchema, regexEscape };
+


### PR DESCRIPTION
## Summary
- add Gemini client and tooling for product queries
- expose /ai/chat route for AI chatbot responses
- include sanitization utilities and dependencies

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689c564ebf8083309c74cd67e41c596d

## Summary by Sourcery

Implement an AI-driven chatbot endpoint that forwards user messages to Google Gemini, executes defined product search and SKU retrieval tools using sanitized inputs, and returns the AI’s response.

New Features:
- Expose POST /ai/chat route for AI chatbot interactions using Google Gemini
- Add searchProducts and getProductBySku tools for product queries

Enhancements:
- Introduce Zod-based sanitization utilities for validating chatbot tool inputs
- Implement Gemini client wrapper with cached model instantiation and tool dispatch

Build:
- Add @google/generative-ai and zod dependencies to package.json