### PR TITLE
Fix category lookup casting in AI search tool

### DIFF
--- a/ai/tools.js
+++ b/ai/tools.js
@@ -1,4 +1,6 @@
 const Product = require('../models/Product');
+const Category = require('../models/Category');
+const mongoose = require('mongoose');
 const { searchSchema, skuSchema, regexEscape } = require('../utils/sanitize');
 
 // Tell Gemini what tools exist and what args they take
@@ -48,7 +50,19 @@ async function run_searchProducts(rawArgs) {
   const args = searchSchema.parse(rawArgs || {});
   const query = {};
 
-  if (args.category) query.category_id = args.category;
+  if (args.category) {
+    if (mongoose.Types.ObjectId.isValid(args.category)) {
+      query.category_id = args.category;
+    } else {
+      const cat = await Category.findOne({ name: args.category }).select('_id').lean();
+      if (cat) {
+        query.category_id = cat._id;
+      } else {
+        return { ok: true, data: [] };
+      }
+    }
+  }
+
   if (args.inStock === true) query.stock = { $gt: 0 };
   if (args.priceMin != null || args.priceMax != null) {
     query.price = {};


### PR DESCRIPTION
## Summary
- resolve CastError when filtering products by category by mapping string names to ObjectId
- ensure invalid category names return empty results instead of throwing

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689c5d0b4efc8330a299e94414680866

## Summary by Sourcery

Enhance the AI search tool to accept category names, validate or convert them to ObjectIds, and return empty results for invalid inputs to prevent casting errors.

New Features:
- Allow filtering products by category name strings as well as ObjectIds

Bug Fixes:
- Prevent CastError by validating category inputs and handle invalid names by returning an empty result set

Enhancements:
- Map string category names to ObjectIds for search queries