### PR TITLE
Fix AI search category lookup and Gemini function response handling

### DIFF
--- a/ai/tools.js
+++ b/ai/tools.js
@@ -1,4 +1,6 @@
 const Product = require('../models/Product');
+const Category = require('../models/Category');
+const mongoose = require('mongoose');
 const { searchSchema, skuSchema, regexEscape } = require('../utils/sanitize');
 
 // Tell Gemini what tools exist and what args they take
@@ -48,7 +50,19 @@ async function run_searchProducts(rawArgs) {
   const args = searchSchema.parse(rawArgs || {});
   const query = {};
 
-  if (args.category) query.category_id = args.category;
+  if (args.category) {
+    if (mongoose.Types.ObjectId.isValid(args.category)) {
+      query.category_id = args.category;
+    } else {
+      const cat = await Category.findOne({ name: args.category }).select('_id').lean();
+      if (cat) {
+        query.category_id = cat._id;
+      } else {
+        return { ok: true, data: [] };
+      }
+    }
+  }
+
   if (args.inStock === true) query.stock = { $gt: 0 };
   if (args.priceMin != null || args.priceMax != null) {
     query.price = {};

--- a/routes/chat.js
+++ b/routes/chat.js
@@ -16,8 +16,15 @@ router.post('/chat', async (req, res) => {
       ],
     });
 
-    const parts = first.response.candidates?.[0]?.content?.parts || [];
+    const modelContent = first.response.candidates?.[0]?.content;
+    const parts = modelContent?.parts || [];
     const calls = parts.filter((p) => p.functionCall);
+
+    // If Gemini didn't call any tools, return its reply directly
+    if (calls.length === 0) {
+      const text = first.response.text();
+      return res.json({ reply: text });
+    }
 
     // Step 2: execute tool calls (if any)
     const toolParts = [];
@@ -30,7 +37,9 @@ router.post('/chat', async (req, res) => {
     // Step 3: give tool results back to Gemini to compose natural reply
     const final = await model.generateContent({
       contents: [
+        { role: 'user', parts: [{ text: SYSTEM_PROMPT }] },
         { role: 'user', parts: [{ text: userMsg }] },
+        modelContent,
         ...toolParts.map((tp) => ({ role: 'tool', parts: [tp] })),
       ],
     });


### PR DESCRIPTION
## Summary
- resolve CastError when filtering products by category by mapping string names to ObjectId
- ensure invalid category names return empty results instead of throwing
- pair Gemini chat function calls with their responses and skip second request when no tools are used

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689c5d0b4efc8330a299e94414680866

## Summary by Sourcery

Fix category filtering in AI product search and streamline chat endpoint function response handling.

Bug Fixes:
- Map string category names to ObjectId in product search and return empty results for invalid categories to avoid CastError

Enhancements:
- Short-circuit chat endpoint to return direct LLM reply when no tools are invoked
- Include original function call content in follow-up model requests for tool execution context