### PR TITLE
Fix AI search category and SKU lookups plus Gemini function responses

### DIFF
--- a/ai/tools.js
+++ b/ai/tools.js
@@ -1,5 +1,7 @@
 const Product = require('../models/Product');
-const { searchSchema, skuSchema, regexEscape } = require('../utils/sanitize');
+const Category = require('../models/Category');
+const mongoose = require('mongoose');
+const { searchSchema, idSchema, regexEscape } = require('../utils/sanitize');
 
 // Tell Gemini what tools exist and what args they take
 const functionDeclarations = [
@@ -21,12 +23,12 @@ const functionDeclarations = [
     },
   },
   {
-    name: 'getProductBySku',
-    description: 'Get a single product by SKU.',
+    name: 'getProductById',
+    description: 'Get a single product by ID.',
     parameters: {
       type: 'OBJECT',
-      properties: { sku: { type: 'STRING' } },
-      required: ['sku'],
+      properties: { id: { type: 'STRING' } },
+      required: ['id'],
     },
   },
 ];
@@ -48,7 +50,19 @@ async function run_searchProducts(rawArgs) {
   const args = searchSchema.parse(rawArgs || {});
   const query = {};
 
-  if (args.category) query.category_id = args.category;
+  if (args.category) {
+    if (mongoose.Types.ObjectId.isValid(args.category)) {
+      query.category_id = args.category;
+    } else {
+      const cat = await Category.findOne({ name: args.category }).select('_id').lean();
+      if (cat) {
+        query.category_id = cat._id;
+      } else {
+        return { ok: true, data: [] };
+      }
+    }
+  }
+
   if (args.inStock === true) query.stock = { $gt: 0 };
   if (args.priceMin != null || args.priceMax != null) {
     query.price = {};
@@ -72,20 +86,23 @@ async function run_searchProducts(rawArgs) {
     .lean();
 
   const mapped = docs.map((d) => ({
-    sku: String(d._id),
+    _id: String(d._id),
     name: d.name,
     price: d.price,
     stock: d.stock,
-    category: d.category_id,
+    category_id: d.category_id,
     updatedAt: d.updatedAt,
   }));
 
   return { ok: true, data: mapped };
 }
 
-async function run_getProductBySku(rawArgs) {
-  const { sku } = skuSchema.parse(rawArgs || {});
-  const doc = await Product.findById(sku)
+async function run_getProductById(rawArgs) {
+  const { id } = idSchema.parse(rawArgs || {});
+  if (!mongoose.Types.ObjectId.isValid(id)) {
+    return { ok: false, error: 'NOT_FOUND' };
+  }
+  const doc = await Product.findById(id)
     .select('_id name category_id price stock specifications description updatedAt')
     .lean();
   if (!doc) return { ok: false, error: 'NOT_FOUND' };
@@ -93,12 +110,12 @@ async function run_getProductBySku(rawArgs) {
   return {
     ok: true,
     data: {
-      sku: String(doc._id),
+      _id: String(doc._id),
       name: doc.name,
-      category: doc.category_id,
+      category_id: doc.category_id,
       price: doc.price,
       stock: doc.stock,
-      specs: doc.specifications,
+      specifications: doc.specifications,
       description: doc.description,
       updatedAt: doc.updatedAt,
     },
@@ -107,14 +124,14 @@ async function run_getProductBySku(rawArgs) {
 
 async function dispatchTool(name, args) {
   if (name === 'searchProducts') return run_searchProducts(args);
-  if (name === 'getProductBySku') return run_getProductBySku(args);
+  if (name === 'getProductById') return run_getProductById(args);
   return { ok: false, error: 'Unknown tool' };
 }
 
 const SYSTEM_PROMPT = `Bạn là trợ lý bán hàng cho cửa hàng điện thoại/phụ kiện.
 - Khi câu hỏi cần giá/tồn kho/chi tiết sản phẩm → gọi tool tương ứng.
 - Không tiết lộ dữ liệu nội bộ (PII, giá nhập, biên lợi nhuận).
-- Trả lời ngắn gọn bằng tiếng Việt, ghi giá VND, kèm SKU khi trích từ DB.`;
+  - Trả lời ngắn gọn bằng tiếng Việt, ghi giá VND, kèm ID sản phẩm khi trích từ DB.`;
 
 module.exports = { functionDeclarations, dispatchTool, SYSTEM_PROMPT };
 

--- a/routes/chat.js
+++ b/routes/chat.js
@@ -16,8 +16,15 @@ router.post('/chat', async (req, res) => {
       ],
     });
 
-    const parts = first.response.candidates?.[0]?.content?.parts || [];
+    const modelContent = first.response.candidates?.[0]?.content;
+    const parts = modelContent?.parts || [];
     const calls = parts.filter((p) => p.functionCall);
+
+    // If Gemini didn't call any tools, return its reply directly
+    if (calls.length === 0) {
+      const text = first.response.text();
+      return res.json({ reply: text });
+    }
 
     // Step 2: execute tool calls (if any)
     const toolParts = [];
@@ -30,7 +37,9 @@ router.post('/chat', async (req, res) => {
     // Step 3: give tool results back to Gemini to compose natural reply
     const final = await model.generateContent({
       contents: [
+        { role: 'user', parts: [{ text: SYSTEM_PROMPT }] },
         { role: 'user', parts: [{ text: userMsg }] },
+        modelContent,
         ...toolParts.map((tp) => ({ role: 'tool', parts: [tp] })),
       ],
     });

--- a/utils/sanitize.js
+++ b/utils/sanitize.js
@@ -12,13 +12,13 @@ const searchSchema = z.object({
   sort: z.enum(["relevance", "price_asc", "price_desc", "updated_desc"]).default("updated_desc"),
 });
 
-// Schema for a single SKU lookup
-const skuSchema = z.object({ sku: z.string().trim().min(1) });
+// Schema for a single product ID lookup
+const idSchema = z.object({ id: z.string().trim().min(1) });
 
 // Escape regex special characters
 function regexEscape(s) {
   return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
-module.exports = { searchSchema, skuSchema, regexEscape };
+module.exports = { searchSchema, idSchema, regexEscape };
 


### PR DESCRIPTION
## Summary
- resolve CastError when filtering products by category by mapping string names to ObjectId
- ensure invalid category names return empty results instead of throwing
- pair Gemini chat function calls with their responses and skip second request when no tools are used
- validate product IDs before querying to prevent CastError and return not found for invalid IDs
- align AI tool field names (e.g., `_id`, `category_id`, `specifications`) with existing models and routes

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689c5d0b4efc8330a299e94414680866

## Summary by Sourcery

Improve AI search tools to robustly handle category and product ID lookups, standardize tool field naming, and streamline the chat route to avoid unnecessary follow-up requests.

Bug Fixes:
- Prevent CastError when filtering products by category by mapping string names to ObjectId and returning empty results for invalid names
- Validate product IDs before querying to avoid CastError and return NOT_FOUND for invalid IDs

Enhancements:
- Rename AI tool and schema from getProductBySku/skuSchema to getProductById/idSchema and align field names (_id, category_id, specifications) with models
- Pair Gemini function calls with their responses and skip the second model request when no tools are invoked