### PR TITLE
fix: convert admin queries to plain objects

### DIFF
--- a/routes/admin.js
+++ b/routes/admin.js
@@ -31,20 +31,24 @@ router.get('/users/:id/edit', async (req, res) => {
 router.get('/products', async (req, res) => {
   const products = await Product.find()
     .populate('category_id', 'name')
-    .populate('brand_id', 'name');
+    .populate('brand_id', 'name')
+    .lean();
   res.render('admin/products-static', { layout: 'admin/layout', products });
 });
 router.get('/products/create', async (req, res) => {
-  const [categories, brands] = await Promise.all([Category.find(), Brand.find()]);
+  const [categories, brands] = await Promise.all([
+    Category.find().lean(),
+    Brand.find().lean()
+  ]);
   res.render('admin/form', { layout: 'admin/layout', categories, brands, product: {} });
 });
 router.get('/products/:id/edit', async (req, res) => {
   const [product, categories, brands] = await Promise.all([
-    Product.findById(req.params.id),
-    Category.find(),
-    Brand.find()
+    Product.findById(req.params.id).lean(),
+    Category.find().lean(),
+    Brand.find().lean()
   ]);
-  const tsktTemplates = await TsktProduct.find({ category_id: product.category_id });
+  const tsktTemplates = await TsktProduct.find({ category_id: product.category_id }).lean();
   res.render('admin/form', { layout: 'admin/layout', product, categories, brands, tsktTemplates });
 });
 


### PR DESCRIPTION
## Summary
- convert Product/Category/Brand/Tskt queries to `.lean()` when rendering admin views
- prevent Handlebars prototype access error for Mongoose docs

## Testing
- `npm test` *(fails: Missing script: "test")*
- `node -e "const hbs=require('hbs'); const mongoose=require('mongoose'); const schema=new mongoose.Schema({name:String}); const Model=mongoose.model('T',schema); const doc=new Model({name:'A'}); console.log(hbs.handlebars.compile('{{name}}')(doc.toObject()));"`

------
https://chatgpt.com/codex/tasks/task_e_689c7ad5de1083308a5b92c919b7fc25

## Summary by Sourcery

Convert admin product, category, brand, and TsktProduct queries to use .lean() for plain objects in views

Bug Fixes:
- Prevent Handlebars prototype access errors by rendering plain JavaScript objects instead of Mongoose documents

Enhancements:
- Add .lean() to Product.find(), Category.find(), Brand.find(), Product.findById(), and TsktProduct.find() in admin routes