### PR TITLE
fix: convert admin queries to plain objects

### DIFF
--- a/public/admin/static/js/admin.js
+++ b/public/admin/static/js/admin.js
@@ -130,6 +130,11 @@ async function initProductForm() {
   const imageFileGroup = document.getElementById("imageFileGroup");
   const imageLinkGroup = document.getElementById("imageLinkGroup");
 
+  const getSpecInputs = () =>
+    Array.from(specContainer.querySelectorAll(".spec-item input")).filter(
+      inp => inp.previousElementSibling && inp.previousElementSibling.tagName === "LABEL"
+    );
+
   let editor;
 
   if (!form || !categorySelect || !specContainer || !descInput || !descEditorEl) {
@@ -353,7 +358,7 @@ async function initProductForm() {
           // Fill spec values
           const specList = Array.isArray(prod.tskt) ? prod.tskt : prod.specifications || [];
           specList.forEach(spec => {
-            const input = Array.from(specContainer.querySelectorAll(".spec-item input")).find(
+            const input = getSpecInputs().find(
               inp => inp.previousElementSibling.textContent === spec.key || inp.previousElementSibling.textContent === spec.label
             );
             if (input) input.value = spec.value;
@@ -435,8 +440,7 @@ async function initProductForm() {
         stock: parseInt(fd.get("stock")),
         image: imageUrl,
         description: fd.get("description"),
-        specifications: Array.from(specContainer.querySelectorAll(".spec-item input"))
-          .filter(inp => inp.previousElementSibling && inp.previousElementSibling.tagName === "LABEL")
+        specifications: getSpecInputs()
           .map(inp => ({
             key: inp.previousElementSibling.textContent,
             value: inp.value

--- a/public/admin/static/js/admin.js
+++ b/public/admin/static/js/admin.js
@@ -435,7 +435,8 @@ async function initProductForm() {
         stock: parseInt(fd.get("stock")),
         image: imageUrl,
         description: fd.get("description"),
-        specifications: Array.from(form.querySelectorAll(".spec-item input"))
+        specifications: Array.from(specContainer.querySelectorAll(".spec-item input"))
+          .filter(inp => inp.previousElementSibling && inp.previousElementSibling.tagName === "LABEL")
           .map(inp => ({
             key: inp.previousElementSibling.textContent,
             value: inp.value

--- a/routes/admin.js
+++ b/routes/admin.js
@@ -31,20 +31,24 @@ router.get('/users/:id/edit', async (req, res) => {
 router.get('/products', async (req, res) => {
   const products = await Product.find()
     .populate('category_id', 'name')
-    .populate('brand_id', 'name');
+    .populate('brand_id', 'name')
+    .lean();
   res.render('admin/products-static', { layout: 'admin/layout', products });
 });
 router.get('/products/create', async (req, res) => {
-  const [categories, brands] = await Promise.all([Category.find(), Brand.find()]);
+  const [categories, brands] = await Promise.all([
+    Category.find().lean(),
+    Brand.find().lean()
+  ]);
   res.render('admin/form', { layout: 'admin/layout', categories, brands, product: {} });
 });
 router.get('/products/:id/edit', async (req, res) => {
   const [product, categories, brands] = await Promise.all([
-    Product.findById(req.params.id),
-    Category.find(),
-    Brand.find()
+    Product.findById(req.params.id).lean(),
+    Category.find().lean(),
+    Brand.find().lean()
   ]);
-  const tsktTemplates = await TsktProduct.find({ category_id: product.category_id });
+  const tsktTemplates = await TsktProduct.find({ category_id: product.category_id }).lean();
   res.render('admin/form', { layout: 'admin/layout', product, categories, brands, tsktTemplates });
 });
 


### PR DESCRIPTION
## Summary
- convert Product/Category/Brand/Tskt queries to `.lean()` when rendering admin views
- filter variant inputs when serializing specifications in admin.js to avoid missing `previousElementSibling`

## Testing
- `npm test` *(fails: Missing script: "test")*
- `node - <<'NODE'
const specContainer = { querySelectorAll: () => [
  { previousElementSibling: { tagName: 'LABEL', textContent: 'Color' }, value: 'red' },
  { previousElementSibling: null, value: 'unused' }
]};
const specs = Array.from(specContainer.querySelectorAll('.spec-item input'))
  .filter(inp => inp.previousElementSibling && inp.previousElementSibling.tagName === 'LABEL')
  .map(inp => ({ key: inp.previousElementSibling.textContent, value: inp.value }))
  .filter(item => item.key && item.value.trim());
console.log(specs);
NODE`


------
https://chatgpt.com/codex/tasks/task_e_689c7ad5de1083308a5b92c919b7fc25

## Summary by Sourcery

Convert admin data queries to return plain JavaScript objects and filter specification inputs to avoid rendering errors

Bug Fixes:
- Filter specification inputs by checking for a preceding LABEL element to avoid missing previousElementSibling errors

Enhancements:
- Use .lean() on Product, Category, Brand, and TsktProduct queries in admin routes to return plain objects