### PR TITLE
feat: allow uploading user avatars

### DIFF
--- a/controllers/productCtrl.js
+++ b/controllers/productCtrl.js
@@ -5,6 +5,31 @@ const Order = require('../models/Order'); // Thêm dòng này ở đầu file n�
 const mongoose    = require('mongoose');
 // controllers/productCtrl.js
 
+// Convert various client variant formats into the schema expected by Product model
+function normalizeVariants(raw) {
+  if (!Array.isArray(raw)) return [];
+  return raw
+    .map(group => {
+      // accept both `key` and older `name` field for group name
+      const key = group.key || group.name;
+      if (!key) return null;
+
+      // options may be provided either as full objects or simple string arrays
+      let opts = [];
+      if (Array.isArray(group.options)) {
+        opts = group.options.map(opt => ({
+          label: opt.label ?? opt,
+          priceDiff: opt.priceDiff ?? 0
+        }));
+      } else if (Array.isArray(group.values)) {
+        opts = group.values.map(v => ({ label: v, priceDiff: 0 }));
+      }
+
+      return { key, options: opts };
+    })
+    .filter(Boolean);
+}
+
 // Create product
 exports.createProduct = async (req, res) => {
   try {
@@ -27,10 +52,9 @@ exports.createProduct = async (req, res) => {
     // Parse và validate variants
     let parsedVariants = [];
     try {
-      parsedVariants = JSON.parse(variants);
-      if (!Array.isArray(parsedVariants)) {
-        throw new Error();
-      }
+      const raw = JSON.parse(variants);
+      if (!Array.isArray(raw)) throw new Error();
+      parsedVariants = normalizeVariants(raw);
     } catch (e) {
       return res.status(400).json({ error: 'variants phải là JSON mảng hợp lệ' });
     }
@@ -84,10 +108,9 @@ exports.updateProduct = async (req, res) => {
 
     let parsedVariants = [];
     try {
-      parsedVariants = JSON.parse(variants);
-      if (!Array.isArray(parsedVariants)) {
-        throw new Error();
-      }
+      const raw = JSON.parse(variants);
+      if (!Array.isArray(raw)) throw new Error();
+      parsedVariants = normalizeVariants(raw);
     } catch (e) {
       return res.status(400).json({ error: 'variants phải là JSON mảng hợp lệ' });
     }

--- a/public/admin/static/js/user-form.js
+++ b/public/admin/static/js/user-form.js
@@ -1,9 +1,34 @@
 const API_REGISTER = '/users/register';
 const API_USER = '/users';
+const API_UPLOAD = '/users/upload';
 
 document.addEventListener('DOMContentLoaded', () => {
   const form = document.getElementById('userForm');
   if (!form) return;
+
+  const avatarInput = document.getElementById('avatar');
+  const avatarPreview = document.getElementById('avatarPreview');
+
+  // Ensure existing avatar path is absolute
+  if (avatarPreview && avatarPreview.src) {
+    const src = avatarPreview.getAttribute('src');
+    if (src && !src.startsWith('http') && src.trim() !== '') {
+      avatarPreview.src = '/' + src.replace(/^\/+/, '');
+      avatarPreview.classList.remove('d-none');
+    }
+  }
+
+  // Preview avatar when file selected
+  if (avatarInput) {
+    avatarInput.addEventListener('change', e => {
+      const file = e.target.files[0];
+      if (file && avatarPreview) {
+        avatarPreview.src = URL.createObjectURL(file);
+        avatarPreview.classList.remove('d-none');
+      }
+    });
+  }
+
   form.addEventListener('submit', async e => {
     e.preventDefault();
     const fd = new FormData(form);
@@ -33,6 +58,20 @@ document.addEventListener('DOMContentLoaded', () => {
       return;
     }
     try {
+      // Upload avatar file if provided
+      if (avatarInput && avatarInput.files[0]) {
+        const upFd = new FormData();
+        upFd.append('file', avatarInput.files[0]);
+        const upRes = await fetch(API_UPLOAD, { method: 'POST', body: upFd });
+        if (!upRes.ok) {
+          const data = await upRes.json().catch(() => ({}));
+          alert('Lỗi upload: ' + (data.message || upRes.status));
+          return;
+        }
+        const upData = await upRes.json();
+        payload.avatarUrl = upData.url;
+      }
+
       const res = await fetch(url, {
         method,
         headers: { 'Content-Type': 'application/json' },

--- a/public/admin/static/js/user.js
+++ b/public/admin/static/js/user.js
@@ -37,7 +37,9 @@ function renderUsers(users, append = false) {
   if (!append) tbody.innerHTML = '';
   users.forEach(u => {
     const tr = document.createElement('tr');
-    const avatarUrl = u.avatar || 'https://via.placeholder.com/40';
+    const avatarUrl = u.avatar
+      ? (u.avatar.startsWith('http') ? u.avatar : '/' + u.avatar.replace(/^\/+/, ''))
+      : 'https://via.placeholder.com/40';
     tr.innerHTML = `
       <td class="px-6 py-4"><img src="${avatarUrl}" alt="avatar" class="w-10 h-10 rounded-full object-cover"></td>
       <td class="px-6 py-4">${u.name}</td>

--- a/routes/users.js
+++ b/routes/users.js
@@ -53,7 +53,8 @@ router.post('/register', async (req, res) => {
       label,
       provinceId,
       districtId,
-      wardCode
+      wardCode,
+      avatarUrl
     } = req.body;
 
     // Check if user already exists
@@ -64,24 +65,38 @@ router.post('/register', async (req, res) => {
     // Hash password
     const hashedPassword = await bcrypt.hash(password, 10);
 
+    // Process avatarUrl similar to update route
+    let processedAvatar = '';
+    if (typeof avatarUrl === 'string') {
+      if (avatarUrl.startsWith('data:')) {
+        processedAvatar = '';
+      } else if (avatarUrl.startsWith('http')) {
+        const host = `${req.protocol}://${req.get('host')}/`;
+        processedAvatar = avatarUrl.replace(host, '');
+      } else {
+        processedAvatar = avatarUrl;
+      }
+    }
+
     // Create user
     const newUser = new User({
-  full_name,
-  email,
-  password: hashedPassword,
-  phone,
-  address, // vẫn giữ cho user cũ nếu muốn
-  addresses: [
-    {
-      label,
-      address,
-      provinceId,
-      districtId,
-      wardCode,
-      isDefault: true
-    }
-  ]
-});
+      full_name,
+      email,
+      password: hashedPassword,
+      phone,
+      address, // vẫn giữ cho user cũ nếu muốn
+      avatarUrl: processedAvatar,
+      addresses: [
+        {
+          label,
+          address,
+          provinceId,
+          districtId,
+          wardCode,
+          isDefault: true
+        }
+      ]
+    });
 
     await newUser.save();
 

--- a/views/admin/user-form.hbs
+++ b/views/admin/user-form.hbs
@@ -187,6 +187,13 @@
         <input type="text" class="form-control" id="address" name="address" value="{{user.address}}">
       </div>
     </div>
+    <div class="mb-3">
+      <label class="form-label" for="avatar">Ảnh đại diện</label>
+      <div class="mb-2">
+        <img id="avatarPreview" src="{{user.avatarUrl}}" class="rounded-circle {{#unless user.avatarUrl}}d-none{{/unless}}" style="width:80px;height:80px;object-fit:cover;" alt="Avatar">
+      </div>
+      <input type="file" class="form-control" id="avatar" name="avatar" accept="image/*">
+    </div>
     <div class="modal-footer">
       <button type="submit" class="btn btn-primary px-4">
         <i class="fas fa-save me-2"></i>Lưu


### PR DESCRIPTION
## Summary
- add avatar file upload in admin user form
- store uploaded avatar URLs when registering users
- show correct avatar paths in user list
- normalize product variant format when creating or updating products

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689f4047cfcc8330bd938dba404ef7c9

## Summary by Sourcery

Add support for user avatar uploads in the admin UI and backend registration, ensure stored avatar URLs are processed and displayed correctly, and standardize product variant formats in create and update endpoints.

New Features:
- Add avatar file input and preview in the admin user form with upload endpoint integration
- Save and process avatarUrl on user registration to store the correct relative path
- Display user avatars in the user list with a placeholder fallback

Enhancements:
- Introduce normalizeVariants helper to standardize various product variant formats in create and update product controllers