### PR TITLE
feat: add order detail modal

### DIFF
--- a/routes/orders.js
+++ b/routes/orders.js
@@ -52,7 +52,7 @@ router.get('/', async (req, res) => {
     let orders = await Order.find(filter)
       .populate('products.productId')
       .populate('combos.comboId')
-      .populate('user_id', 'full_name')
+      .populate('user_id', 'full_name phone')
       .sort({ createdAt: -1 })
       .skip(skip)
       .limit(parseInt(limit))
@@ -418,7 +418,7 @@ router.put('/:id', async (req, res) => {
 router.get('/:id', async (req, res) => {
   try {
     const order = await Order.findById(req.params.id)
-      .populate('user_id', 'full_name email')
+      .populate('user_id', 'full_name phone email')
       .populate('products.productId', 'name price image')
       .populate('combos.comboId')
       .lean();

--- a/views/admin/order.hbs
+++ b/views/admin/order.hbs
@@ -258,11 +258,27 @@
   </div>
 </div>
 
+    <!-- Modal xem chi tiết đơn hàng -->
+<div id="viewOrderModal" class="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-40 hidden">
+  <div class="bg-white rounded-2xl shadow-xl p-6 w-full max-w-2xl relative" style="max-height:80vh; overflow-y:auto;">
+    <button id="closeViewModal" class="absolute top-3 right-4 text-gray-400 hover:text-red-500 text-xl">
+      <i class="fas fa-times"></i>
+    </button>
+    <div id="viewOrderContent">
+      <div class="text-center text-gray-400 py-8">Đang tải...</div>
+    </div>
+  </div>
+</div>
+
     <script>
-        // Move edit modal to body to prevent transform issues
+        // Move modals to body to prevent transform issues
         const editOrderModalEl = document.getElementById('editOrderModal');
         if (editOrderModalEl && editOrderModalEl.parentNode !== document.body) {
             document.body.appendChild(editOrderModalEl);
+        }
+        const viewOrderModalEl = document.getElementById('viewOrderModal');
+        if (viewOrderModalEl && viewOrderModalEl.parentNode !== document.body) {
+            document.body.appendChild(viewOrderModalEl);
         }
         let currentStatus = '';
         let currentOrders = [];
@@ -308,21 +324,23 @@
         function getStatusIcon(status) {
             const icons = {
                 pending: 'fas fa-clock',
-                confirmed: 'fas fa-check-circle',
-                shipped: 'fas fa-truck',
+                packed: 'fas fa-box',
+                shipping: 'fas fa-truck',
                 delivered: 'fas fa-check-double',
-                canceled: 'fas fa-times-circle'
+                return_requested: 'fas fa-undo-alt',
+                cancelled: 'fas fa-times-circle'
             };
             return icons[status] || 'fas fa-question-circle';
         }
 
         function getStatusText(status) {
             const texts = {
-                pending: 'Chờ xử lý',
-                confirmed: 'Đã xác nhận',
-                shipped: 'Đang giao',
+                pending: 'Chờ xác nhận',
+                packed: 'Chờ lấy hàng',
+                shipping: 'Chờ giao hàng',
                 delivered: 'Đã giao',
-                canceled: 'Đã hủy'
+                return_requested: 'Trả hàng',
+                cancelled: 'Đã huỷ'
             };
             return texts[status] || status;
         }
@@ -413,11 +431,11 @@
                     </td>
                     <td class="px-6 py-4 whitespace-nowrap text-center" data-label="Hành động">
                         <div class="flex justify-center space-x-2">
-                            <button onclick="editOrder('${order._id}')" class="btn-secondary text-white px-3 py-2 rounded-lg text-sm font-medium shadow-md icon-bounce">
-                                <i class="fas fa-edit"></i>
+                            <button onclick="viewOrder('${order._id}')" class="btn-secondary text-white px-3 py-2 rounded-lg text-sm font-medium shadow-md icon-bounce">
+                                <i class="fas fa-eye"></i>
                             </button>
-                            <button onclick="deleteOrder('${order._id}')" class="btn-danger text-white px-3 py-2 rounded-lg text-sm font-medium shadow-md icon-bounce">
-                                <i class="fas fa-trash"></i>
+                            <button onclick="editOrder('${order._id}')" class="btn-danger text-white px-3 py-2 rounded-lg text-sm font-medium shadow-md icon-bounce">
+                                <i class="fas fa-sync-alt"></i>
                             </button>
                         </div>
                     </td>
@@ -445,6 +463,62 @@
             }
         }
 
+        async function viewOrder(id) {
+            const modal = document.getElementById('viewOrderModal');
+            const container = document.getElementById('viewOrderContent');
+            modal.classList.remove('hidden');
+            container.innerHTML = '<div class="text-center text-gray-400 py-8">Đang tải...</div>';
+            try {
+                const res = await fetch(`/orders/${id}`);
+                const order = await res.json();
+                const total = new Intl.NumberFormat('vi-VN', {
+                    style: 'currency',
+                    currency: 'VND'
+                }).format(order.total || 0);
+                let productsHtml = '';
+                if (Array.isArray(order.products)) {
+                    productsHtml = order.products.map(p => {
+                        const img = p.productId?.image || 'https://via.placeholder.com/80';
+                        const name = p.productId?.name || '';
+                        const variant = p.variant?.label || '';
+                        const qty = p.quantity || 0;
+                        const price = new Intl.NumberFormat('vi-VN', {
+                            style: 'currency',
+                            currency: 'VND'
+                        }).format((p.productId?.price || 0) + (p.variant?.priceDiff || 0));
+                        return `<div class="flex items-center mb-4">
+                                    <img src="${img}" class="w-16 h-16 object-cover rounded mr-4" alt="${name}">
+                                    <div class="flex-1">
+                                        <div class="font-medium">${name}</div>
+                                        <div class="text-sm text-gray-500">${variant}</div>
+                                    </div>
+                                    <div class="text-sm text-gray-500 mr-4">x${qty}</div>
+                                    <div class="font-semibold">${price}</div>
+                                </div>`;
+                    }).join('');
+                }
+                const receiverName = order.user_id?.full_name || '';
+                const receiverPhone = order.user_id?.phone || '';
+                const receiverAddress = order.address || '';
+                container.innerHTML = `
+                    <h2 class="text-xl font-bold mb-4">Đơn hàng #${order._id}</h2>
+                    <div class="mb-4">
+                        <div class="mb-2"><strong>Người nhận:</strong> ${receiverName}</div>
+                        <div class="mb-2"><strong>SĐT:</strong> ${receiverPhone}</div>
+                        <div class="mb-2"><strong>Địa chỉ:</strong> ${receiverAddress}</div>
+                        <div class="mb-2"><strong>Phương thức thanh toán:</strong> ${order.paymentMethod || ''}</div>
+                        <div class="mb-2"><strong>Tổng giá trị:</strong> ${total}</div>
+                    </div>
+                    <div>
+                        <h3 class="text-lg font-semibold mb-2">Sản phẩm</h3>
+                        ${productsHtml}
+                    </div>
+                `;
+            } catch (err) {
+                container.innerHTML = '<div class="text-center text-red-500 py-8">Không thể tải chi tiết đơn hàng</div>';
+            }
+        }
+
         function editOrder(id) {
             // Hiện modal
             document.getElementById('editOrderModal').classList.remove('hidden');
@@ -460,15 +534,22 @@
         }
 
         const editModal = document.getElementById('editOrderModal');
+        const viewModal = document.getElementById('viewOrderModal');
 
         // Đóng modal khi bấm nút đóng
         document.getElementById('closeEditModal').addEventListener('click', () => {
             editModal.classList.add('hidden');
         });
+        document.getElementById('closeViewModal').addEventListener('click', () => {
+            viewModal.classList.add('hidden');
+        });
 
         // Đóng modal khi click ra ngoài
         editModal.addEventListener('click', (e) => {
             if (e.target === editModal) editModal.classList.add('hidden');
+        });
+        viewModal.addEventListener('click', (e) => {
+            if (e.target === viewModal) viewModal.classList.add('hidden');
         });
 
         // Xử lý submit form chỉnh sửa (AJAX)


### PR DESCRIPTION
## Summary
- add order detail modal and repurpose buttons on order management page
- allow viewing recipient, payment and line-item details
- correct status labels and icons and show recipient info

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689f52a665d88330a5c685897b454d75

## Summary by Sourcery

Add a view-order modal for admins to inspect full order details, adjust action buttons accordingly, refine status displays, and surface customer phone info via API

New Features:
- Add an order detail modal to the admin orders page with AJAX fetching and rendering of recipient, payment, and line-item details

Enhancements:
- Repurpose the table action buttons to launch view and edit modals instead of edit and delete
- Update order status mappings with additional statuses (packed, shipping, return_requested) and correct labels and icons
- Populate user phone number in order list and detail endpoints for display