### PR TITLE
feat: integrate Expo push notifications

### DIFF
--- a/app.js
+++ b/app.js
@@ -8,6 +8,7 @@ var hbs = require('hbs');
 var fs = require('fs');
 var reportRoutes = require('./routes/reports');
 var notificationsRouter = require('./routes/notifications');
+var pushRouter = require('./routes/push');
 var bannerRoutes = require('./routes/banners');
 var vnpayRouter = require('./routes/vnpay');
 var stripeRouter = require('./routes/stripe');
@@ -115,6 +116,7 @@ app.use('/vnpay', vnpayRouter);
 app.use('/reports', reportRoutes);
 app.use('/notifications', notificationsRouter);
 app.use('/banners', bannerRoutes);
+app.use('/api/push', pushRouter);
 app.use('/pcbuild', pcbuilderRouter);
 app.use('/ai', chatRouter);
 

--- a/controllers/notificationCtrl.js
+++ b/controllers/notificationCtrl.js
@@ -1,5 +1,6 @@
 const Notification = require('../models/Notification');
 const { send } = require('../utils/notificationStream');
+const push = require('../utils/pushSender');
 
 // Tạo thông báo mới
 exports.create = async (req, res) => {
@@ -8,6 +9,10 @@ exports.create = async (req, res) => {
     const notif = await Notification.create({ type, title, message, relatedOrder });
     const populated = await notif.populate({ path: 'relatedOrder', populate: { path: 'user_id', select: 'full_name' } });
     send(populated);
+    // gửi push notification tới tất cả thiết bị đã đăng ký
+    push.sendToAll({ title, message, data: { notificationId: notif._id } }).catch(err => {
+      console.error('push error', err);
+    });
     res.status(201).json(populated);
   } catch (err) {
     res.status(400).json({ error: err.message });

--- a/models/Device.js
+++ b/models/Device.js
@@ -1,0 +1,13 @@
+const mongoose = require('mongoose');
+
+const DeviceSchema = new mongoose.Schema({
+  userId: { type: mongoose.Schema.Types.ObjectId, ref: 'User', index: true },
+  expoPushToken: { type: String, unique: true, required: true },
+  platform: { type: String, enum: ['ios', 'android'], index: true },
+  appVersion: String,
+  locale: String,
+  enabled: { type: Boolean, default: true },
+  lastSeenAt: { type: Date, default: Date.now }
+}, { timestamps: true });
+
+module.exports = mongoose.model('Device', DeviceSchema);

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "countup.js": "^2.9.0",
         "debug": "~2.6.9",
         "dotenv": "^16.5.0",
+        "expo-server-sdk": "^3.15.0",
         "express": "^4.21.2",
         "hbs": "^4.2.0",
         "http-errors": "~1.6.3",
@@ -685,6 +686,12 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
     },
+    "node_modules/err-code": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.3.tgz",
+      "integrity": "sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA==",
+      "license": "MIT"
+    },
     "node_modules/es-define-property": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
@@ -738,6 +745,17 @@
       "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/expo-server-sdk": {
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/expo-server-sdk/-/expo-server-sdk-3.15.0.tgz",
+      "integrity": "sha512-Y71mQ7yeDhq6miHzn4kwRQOjqvBBsWeFXvyS9PYc6uqO/+UiYvrw3vMQiQqRxg2y0qgn9jMsvjf8T+mukSH85A==",
+      "license": "MIT",
+      "dependencies": {
+        "node-fetch": "^2.6.0",
+        "promise-limit": "^2.7.0",
+        "promise-retry": "^2.0.1"
       }
     },
     "node_modules/express": {
@@ -1608,6 +1626,48 @@
         "node": "^18 || ^20 || >= 21"
       }
     },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/node-fetch/node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
+    "node_modules/node-fetch/node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/node-fetch/node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
     "node_modules/node-gyp-build": {
       "version": "4.8.4",
       "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
@@ -1754,6 +1814,25 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/promise-limit": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/promise-limit/-/promise-limit-2.7.0.tgz",
+      "integrity": "sha512-7nJ6v5lnJsXwGprnGXga4wx6d1POjvi5Qmf1ivTRxTjH4Z/9Czja/UCMLVmB9N93GeWOU93XaFaEt6jbuoagNw==",
+      "license": "ISC"
+    },
+    "node_modules/promise-retry": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/promise-retry/-/promise-retry-2.0.1.tgz",
+      "integrity": "sha512-y+WKFlBR8BGXnsNlIHFGPZmyDf3DFMoLhaflAnyZgV6rG6xu+JwesTo2Q9R6XwYmtmwAFCkAk3e35jEdoeh/3g==",
+      "license": "MIT",
+      "dependencies": {
+        "err-code": "^2.0.2",
+        "retry": "^0.12.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -1889,6 +1968,15 @@
       },
       "engines": {
         "node": ">=8.10.0"
+      }
+    },
+    "node_modules/retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
       }
     },
     "node_modules/safe-buffer": {

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "dev": "nodemon ./bin/www"
   },
   "dependencies": {
+    "@google/generative-ai": "^0.24.1",
     "axios": "^1.11.0",
     "bcrypt": "^6.0.0",
     "bcryptjs": "^3.0.2",
@@ -15,6 +16,7 @@
     "countup.js": "^2.9.0",
     "debug": "~2.6.9",
     "dotenv": "^16.5.0",
+    "expo-server-sdk": "^3.15.0",
     "express": "^4.21.2",
     "hbs": "^4.2.0",
     "http-errors": "~1.6.3",
@@ -28,7 +30,6 @@
     "stripe": "^18.3.0",
     "vnpay": "^2.4.0",
     "xlsx": "^0.18.5",
-    "@google/generative-ai": "^0.24.1",
     "zod": "^4.0.17"
   },
   "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"

--- a/routes/push.js
+++ b/routes/push.js
@@ -1,0 +1,22 @@
+const router = require('express').Router();
+const Device = require('../models/Device');
+
+// Register or update device push token
+router.post('/register-device', async (req, res) => {
+  const { userId, expoPushToken, platform, appVersion, locale } = req.body;
+  if (!expoPushToken || !expoPushToken.startsWith('ExponentPushToken[')) {
+    return res.status(400).json({ error: 'Invalid Expo push token' });
+  }
+  try {
+    const device = await Device.findOneAndUpdate(
+      { expoPushToken },
+      { userId, platform, appVersion, locale, enabled: true, lastSeenAt: new Date() },
+      { new: true, upsert: true }
+    );
+    res.json({ ok: true, deviceId: device._id });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+module.exports = router;

--- a/utils/pushSender.js
+++ b/utils/pushSender.js
@@ -1,0 +1,32 @@
+const { Expo } = require('expo-server-sdk');
+const Device = require('../models/Device');
+
+const expo = new Expo();
+
+async function sendToAll({ title, message, data = {} }) {
+  const devices = await Device.find({ enabled: true }).lean();
+  const messages = [];
+
+  for (const device of devices) {
+    if (!Expo.isExpoPushToken(device.expoPushToken)) continue;
+    messages.push({
+      to: device.expoPushToken,
+      sound: 'default',
+      title,
+      body: message,
+      data,
+      priority: device.platform === 'android' ? 'high' : 'default'
+    });
+  }
+
+  const chunks = expo.chunkPushNotifications(messages);
+  for (const chunk of chunks) {
+    try {
+      await expo.sendPushNotificationsAsync(chunk);
+    } catch (err) {
+      console.error('Expo push error:', err);
+    }
+  }
+}
+
+module.exports = { sendToAll };

--- a/views/admin/thongbao.hbs
+++ b/views/admin/thongbao.hbs
@@ -1,13 +1,4 @@
-<link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
-<!-- Toastr CSS -->
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/toastr.js/latest/toastr.min.css" />
-
 <style>
-  body {
-    background: linear-gradient(120deg, #a18cd1 0%, #fbc2eb 100%);
-    font-family: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
-    min-height: 100vh;
-  }
   .card {
     border-radius: 1.2rem;
     box-shadow: 0 4px 24px 0 rgba(161,140,209,0.10);
@@ -197,26 +188,10 @@
   </div>
 </div>
 
-<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
-<script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/toastr.js/latest/toastr.min.js"></script>
-
 <script>
-  // Hàm hiển thị toastr notification
+  // Hiển thị thông báo đơn giản
   function notify(type, title, message) {
-    toastr.options = {
-      "closeButton": true,
-      "progressBar": true,
-      "positionClass": "toast-top-right",
-      "timeOut": "5000"
-    };
-    switch(type) {
-      case 'success': toastr.success(message, title); break;
-      case 'info':    toastr.info(message, title);    break;
-      case 'warning': toastr.warning(message, title); break;
-      case 'danger':  toastr.error(message, title);   break;
-      default:        toastr.info(message, title);
-    }
+    alert(`${title}\n${message}`);
   }
 
   let notifications = [];


### PR DESCRIPTION
## Summary
- add Device model and push sender utility using expo-server-sdk
- register device token API and send pushes on new notifications
- simplify admin notification page to match layout

## Testing
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_689f618d94408330bd1179819a73f997

## Summary by Sourcery

Integrate Expo push notifications by adding a Device model, pushSender utility, registration endpoint, and sending push messages on new notifications while simplifying the admin notification view.

New Features:
- Add Device model to store Expo push tokens and device metadata
- Implement pushSender utility to batch and send notifications via expo-server-sdk
- Expose register-device API endpoint to register or update device tokens
- Mount /api/push route for device registration
- Trigger pushSender.sendToAll when creating new notifications

Enhancements:
- Simplify admin notification page by removing Bootstrap/Toastr and using native alerts

Build:
- Add expo-server-sdk dependency