### PR TITLE
Improve product form validation and editing UI

### DIFF
--- a/controllers/productCtrl.js
+++ b/controllers/productCtrl.js
@@ -44,6 +44,17 @@ exports.createProduct = async (req, res) => {
       variants = '[]'          // Mặc định là chuỗi JSON mảng
     } = req.body;
 
+    // Validate required fields
+    if (!name || !category_id || !brand_id || price === undefined || stock === undefined) {
+      return res.status(400).json({ error: 'Thiếu trường bắt buộc' });
+    }
+
+    const priceNum = Number(price);
+    const stockNum = Number(stock);
+    if (Number.isNaN(priceNum) || Number.isNaN(stockNum)) {
+      return res.status(400).json({ error: 'Giá và số lượng phải là số' });
+    }
+
     // Validate specifications
     if (!Array.isArray(specifications)) {
       return res.status(400).json({ error: 'specifications phải là mảng' });
@@ -64,9 +75,9 @@ exports.createProduct = async (req, res) => {
       name,
       category_id,
       brand_id,
-      price,
+      price: priceNum,
       description,
-      stock,
+      stock: stockNum,
       specifications,
       variants: parsedVariants    // Gán mảng nhóm biến thể
     });

--- a/public/admin/static/css/form.css
+++ b/public/admin/static/css/form.css
@@ -11,6 +11,18 @@
   box-shadow: 0 2px 8px rgba(0,0,0,0.1);
 }
 
+/* Form sections */
+.form-section {
+  margin-bottom: 24px;
+}
+.form-section h3 {
+  font-size: 18px;
+  margin-bottom: 12px;
+  color: #4a90e2;
+  border-bottom: 1px solid #e0e0e0;
+  padding-bottom: 4px;
+}
+
 /* Form Groups & Inputs (nếu chưa có) */
 .form-group {
   margin-bottom: 16px;

--- a/routes/admin.js
+++ b/routes/admin.js
@@ -49,7 +49,13 @@ router.get('/products/create', async (req, res) => {
     Category.find().lean(),
     Brand.find().lean()
   ]);
-  res.render('admin/form', { layout: 'admin/layout', categories, brands, product: {} });
+  res.render('admin/form', {
+    layout: 'admin/layout',
+    categories,
+    brands,
+    product: {},
+    mode: 'create'
+  });
 });
 router.get('/products/:id/edit', async (req, res) => {
   const [product, categories, brands] = await Promise.all([
@@ -58,7 +64,14 @@ router.get('/products/:id/edit', async (req, res) => {
     Brand.find().lean()
   ]);
   const tsktTemplates = await TsktProduct.find({ category_id: product.category_id }).lean();
-  res.render('admin/form', { layout: 'admin/layout', product, categories, brands, tsktTemplates });
+  res.render('admin/form', {
+    layout: 'admin/layout',
+    product,
+    categories,
+    brands,
+    tsktTemplates,
+    mode: 'edit'
+  });
 });
 
 // Quản lý Danh mục

--- a/views/admin/form.hbs
+++ b/views/admin/form.hbs
@@ -13,81 +13,93 @@
       <input type="hidden" name="id" value="{{product._id}}">
     {{/ifEquals}}
 
-    <div class="form-group">
-      <label>Danh mục *</label>
-      <select name="category_id" id="categorySelect" required>
-        <option value="">-- Chọn danh mục --</option>
-        {{#each categories}}
-          <option value="{{_id}}" {{#ifEquals _id ../product.category_id._id}}selected{{/ifEquals}}>
-            {{name}}
-          </option>
-        {{/each}}
-      </select>
-    </div>
+    <div class="form-section">
+      <h3>Thông tin cơ bản</h3>
+      <div class="form-group">
+        <label>Danh mục *</label>
+        <select name="category_id" id="categorySelect" required>
+          <option value="">-- Chọn danh mục --</option>
+          {{#each categories}}
+            <option value="{{_id}}" {{#ifEquals _id ../product.category_id._id}}selected{{/ifEquals}}>
+              {{name}}
+            </option>
+          {{/each}}
+        </select>
+      </div>
 
-    <div class="form-group">
-      <label>Thông số kỹ thuật</label>
-      <div id="specContainer">
-        <!-- Specs will be loaded dynamically based on category -->
+      <div class="form-group">
+        <label>Brand *</label>
+        <select name="brand_id" id="brandSpinner" required>
+          <option value="">-- Chọn brand --</option>
+          {{#each brands}}
+            <option value="{{_id}}" {{#ifEquals _id ../product.brand_id._id}}selected{{/ifEquals}}>
+              {{name}}
+            </option>
+          {{/each}}
+        </select>
+      </div>
+
+      <div class="form-group">
+        <label>Tên sản phẩm *</label>
+        <input type="text" name="name" value="{{product.name}}" placeholder="Nhập tên sản phẩm" required>
+      </div>
+
+      <div class="form-group">
+        <label>Giá (VNĐ) *</label>
+        <input type="text" name="price" value="{{product.price}}" placeholder="Nhập giá sản phẩm" required class="number-input">
+      </div>
+
+      <div class="form-group">
+        <label>Số lượng *</label>
+        <input type="text" name="stock" value="{{product.stock}}" placeholder="Nhập số lượng" required class="number-input">
       </div>
     </div>
 
-    <div class="form-group">
-      <label>Biến thể</label>
-      <div id="variantsContainer">
-        <!-- Variants will be loaded dynamically based on category -->
+    <div class="form-section">
+      <h3>Thông số & Biến thể</h3>
+      <div class="form-group">
+        <label>Thông số kỹ thuật</label>
+        <div id="specContainer">
+          <!-- Specs will be loaded dynamically based on category -->
+        </div>
       </div>
-      <button type="button" class="btn btn-sm btn-secondary" id="addVariantBtn">Thêm biến thể tùy chỉnh</button>
-      <input type="hidden" id="variantsInput" name="variants" value="[]">
-    </div>
 
-    <div class="form-group">
-      <label>Brand *</label>
-      <select name="brand_id" id="brandSpinner" required>
-        <option value="">-- Chọn brand --</option>
-        {{#each brands}}
-          <option value="{{_id}}" {{#ifEquals _id ../product.brand_id._id}}selected{{/ifEquals}}>
-            {{name}}
-          </option>
-        {{/each}}
-      </select>
-    </div>
-
-    <div class="form-group">
-      <label>Tên sản phẩm *</label>
-      <input type="text" name="name" value="{{product.name}}" placeholder="Nhập tên sản phẩm" required>
-    </div>
-
-    <div class="form-group">
-      <label>Giá (VNĐ) *</label>
-      <input type="text" name="price" value="{{product.price}}" placeholder="Nhập giá sản phẩm" required class="number-input">
-    </div>
-
-    <div class="form-group">
-      <label>Số lượng *</label>
-      <input type="text" name="stock" value="{{product.stock}}" placeholder="Nhập số lượng" required class="number-input">
-    </div>
-
-    <div class="form-group">
-      <label>Ảnh sản phẩm</label>
-      <select id="imageSourceSelect">
-        <option value="file">Tải lên file</option>
-        <option value="link">Dùng URL</option>
-      </select>
-      <div id="imageFileGroup">
-        <input type="file" id="imageFile" accept="image/*">
+      <div class="form-group">
+        <label>Biến thể</label>
+        <div id="variantsContainer">
+          <!-- Variants will be loaded dynamically based on category -->
+        </div>
+        <button type="button" class="btn btn-sm btn-secondary" id="addVariantBtn">Thêm biến thể tùy chỉnh</button>
+        <input type="hidden" id="variantsInput" name="variants" value="[]">
       </div>
-      <div id="imageLinkGroup" style="display:none;">
-        <input type="text" id="imageLink" placeholder="Dán URL ảnh">
-      </div>
-      <img id="imagePreview" src="{{product.image}}" class="h-24 my-2 max-w-full" {{#unless product.image}}style="display:none"{{/unless}} alt="Product preview">
-      <input type="hidden" name="image" id="imageUrl" value="{{product.image}}">
     </div>
 
-    <div class="form-group">
-      <label>Mô tả</label>
-      <div id="descriptionEditor" style="height:150px; background: white;"></div>
-      <input type="hidden" name="description" id="descriptionInput">
+    <div class="form-section">
+      <h3>Ảnh sản phẩm</h3>
+      <div class="form-group">
+        <label>Ảnh sản phẩm</label>
+        <select id="imageSourceSelect">
+          <option value="file">Tải lên file</option>
+          <option value="link">Dùng URL</option>
+        </select>
+        <div id="imageFileGroup">
+          <input type="file" id="imageFile" accept="image/*">
+        </div>
+        <div id="imageLinkGroup" style="display:none;">
+          <input type="text" id="imageLink" placeholder="Dán URL ảnh">
+        </div>
+        <img id="imagePreview" src="{{product.image}}" class="h-24 my-2 max-w-full" {{#unless product.image}}style="display:none"{{/unless}} alt="Product preview">
+        <input type="hidden" name="image" id="imageUrl" value="{{product.image}}">
+      </div>
+    </div>
+
+    <div class="form-section">
+      <h3>Mô tả</h3>
+      <div class="form-group">
+        <label>Mô tả</label>
+        <div id="descriptionEditor" style="height:150px; background: white;"></div>
+        <input type="hidden" name="description" id="descriptionInput" value="{{product.description}}">
+      </div>
     </div>
 
     <div class="modal-footer">


### PR DESCRIPTION
## Summary
- enforce required field validation when creating products
- add edit/create mode flags and better styling for product form
- ensure product descriptions prefill in edit mode and add basic form sections

## Testing
- `node --check controllers/productCtrl.js`
- `node --check routes/admin.js`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a86898e03883308aa5248821a4d99c