### PR TITLE
feat: separate product image management

### DIFF
--- a/routes/admin.js
+++ b/routes/admin.js
@@ -131,6 +131,10 @@ router.get('/orders/:id/edit', async (req, res) => {
   }
   res.render('admin/order-form', { layout: 'admin/layout', order, mode: 'edit', transitions });
 });
+router.get('/product-images', (req, res) => {
+  res.render('admin/product-images', { layout: 'admin/layout' });
+});
+
 
 router.get('/videos', async (req, res) => {
   const videos = await Video.find().populate({

--- a/views/admin/order.hbs
+++ b/views/admin/order.hbs
@@ -166,10 +166,6 @@
                     Quản lý Đơn hàng
                 </h1>
             </div>
-            {{!-- <a href="/admin/orders/create" class="btn-primary text-white font-semibold shadow-lg">
-                <i class="fas fa-plus"></i>
-                Tạo đơn hàng
-            </a> --}}
         </div>
     </header>
 

--- a/views/admin/product-images.hbs
+++ b/views/admin/product-images.hbs
@@ -1,0 +1,77 @@
+{{#*inline "title"}}Quản lý Hình ảnh Sản phẩm{{/inline}}
+
+<div class="max-w-4xl mx-auto py-8">
+  <h1 class="text-2xl font-bold mb-6">Quản lý Hình ảnh Sản phẩm</h1>
+
+  <form id="imageForm" class="mb-6 space-x-2">
+    <input type="text" id="imageUrlInput" placeholder="URL ảnh" class="border p-2 rounded" required>
+    <input type="text" id="productIdInput" placeholder="ID sản phẩm" class="border p-2 rounded">
+    <input type="text" id="descriptionInput" placeholder="Mô tả" class="border p-2 rounded">
+    <button type="submit" class="btn-primary">Thêm ảnh</button>
+  </form>
+
+  <table class="min-w-full bg-white rounded shadow">
+    <thead>
+      <tr class="bg-gray-100">
+        <th class="px-4 py-2 text-left">Ảnh</th>
+        <th class="px-4 py-2 text-left">Sản phẩm</th>
+        <th class="px-4 py-2 text-left">Mô tả</th>
+        <th class="px-4 py-2">Hành động</th>
+      </tr>
+    </thead>
+    <tbody id="imageBody"></tbody>
+  </table>
+</div>
+
+<script>
+async function loadImages() {
+  const res = await fetch('/images');
+  const data = await res.json();
+  const tbody = document.getElementById('imageBody');
+  tbody.innerHTML = data.map(img => `
+    <tr class="border-b">
+      <td class="px-4 py-2"><img src="${img.url}" class="w-16 h-16 object-cover rounded" alt="img"></td>
+      <td class="px-4 py-2">${img.product_id ? (img.product_id.name || img.product_id) : ''}</td>
+      <td class="px-4 py-2">${img.description || ''}</td>
+      <td class="px-4 py-2 space-x-2">
+        <button onclick="editImage('${img._id}')" class="btn-secondary btn-sm">Sửa</button>
+        <button onclick="deleteImage('${img._id}')" class="btn-danger btn-sm">Xóa</button>
+      </td>
+    </tr>
+  `).join('');
+}
+
+document.getElementById('imageForm').addEventListener('submit', async (e) => {
+  e.preventDefault();
+  const url = document.getElementById('imageUrlInput').value.trim();
+  const product_id = document.getElementById('productIdInput').value.trim() || null;
+  const description = document.getElementById('descriptionInput').value.trim();
+  await fetch('/images', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ url, product_id, description })
+  });
+  e.target.reset();
+  loadImages();
+});
+
+async function editImage(id) {
+  const url = prompt('URL ảnh mới:');
+  if (!url) return;
+  const description = prompt('Mô tả:', '');
+  await fetch(`/images/${id}`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ url, description })
+  });
+  loadImages();
+}
+
+async function deleteImage(id) {
+  if (!confirm('Xóa ảnh này?')) return;
+  await fetch(`/images/${id}`, { method: 'DELETE' });
+  loadImages();
+}
+
+loadImages();
+</script>

--- a/views/admin/products-static.hbs
+++ b/views/admin/products-static.hbs
@@ -9,6 +9,9 @@
     <a href="/admin/products/create" class="btn">
       <i class="bx bx-plus"></i> Thêm sản phẩm
     </a>
+    <a href="/admin/product-images" class="btn ml-2">
+      <i class="bx bx-image"></i> Quản lý hình ảnh
+    </a>
     <input
       type="text"
       id="searchInput"


### PR DESCRIPTION
## Summary
- add dedicated admin page for managing product images with CRUD actions
- link product image manager from static products page instead of orders page

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a8a5dece348330b7e3965c6a3378ae

## Summary by Sourcery

Add a standalone admin interface for managing product images with full CRUD functionality and integrate it into the products page

New Features:
- Introduce a new /admin/product-images route and view for product image management
- Implement client-side scripts to fetch, create, update, and delete product images via the /images API

Enhancements:
- Add a link to the product image manager on the static products admin page
- Clean up the orders view by removing an obsolete create-order button