### PR TITLE
feat: manage images per product

### DIFF
--- a/public/admin/static/js/admin.js
+++ b/public/admin/static/js/admin.js
@@ -96,6 +96,9 @@ function renderProducts(products, append = false) {
            <a href="/admin/products/${p._id}/edit" class="inline-block mx-1 p-2 hover:bg-gray-100 rounded">
              <i class="bx bx-edit text-xl"></i>
            </a>
+           <a href="/admin/product-images?productId=${encodeURIComponent(p._id)}" class="inline-block mx-1 p-2 hover:bg-gray-100 rounded">
+             <i class="bx bx-image text-xl"></i>
+           </a>
            <a href="#" onclick="deleteProduct('${p._id}')" class="inline-block mx-1 p-2 hover:bg-gray-100 rounded">
              <i class="bx bx-trash text-xl"></i>
            </a>

--- a/routes/admin.js
+++ b/routes/admin.js
@@ -131,6 +131,10 @@ router.get('/orders/:id/edit', async (req, res) => {
   }
   res.render('admin/order-form', { layout: 'admin/layout', order, mode: 'edit', transitions });
 });
+router.get('/product-images', (req, res) => {
+  res.render('admin/product-images', { layout: 'admin/layout' });
+});
+
 
 router.get('/videos', async (req, res) => {
   const videos = await Video.find().populate({

--- a/routes/image.js
+++ b/routes/image.js
@@ -2,10 +2,13 @@ const express = require('express');
 const router = express.Router();
 const Image = require('../models/Image');
 
-// GET all images
+// GET all images (optionally filtered by product or category)
 router.get('/', async (req, res) => {
   try {
-    const items = await Image.find().populate('product_id').populate('category_id');
+    const filter = {};
+    if (req.query.product_id) filter.product_id = req.query.product_id;
+    if (req.query.category_id) filter.category_id = req.query.category_id;
+    const items = await Image.find(filter).populate('product_id').populate('category_id');
     res.json(items);
   } catch (err) {
     res.status(500).json({ error: err.message });

--- a/views/admin/order.hbs
+++ b/views/admin/order.hbs
@@ -166,10 +166,6 @@
                     Quản lý Đơn hàng
                 </h1>
             </div>
-            {{!-- <a href="/admin/orders/create" class="btn-primary text-white font-semibold shadow-lg">
-                <i class="fas fa-plus"></i>
-                Tạo đơn hàng
-            </a> --}}
         </div>
     </header>
 

--- a/views/admin/product-images.hbs
+++ b/views/admin/product-images.hbs
@@ -1,0 +1,92 @@
+{{#*inline "title"}}Quản lý Hình ảnh Sản phẩm{{/inline}}
+
+<div class="max-w-4xl mx-auto py-8">
+  <h1 class="text-2xl font-bold mb-6">Quản lý Hình ảnh: <span id="productName"></span></h1>
+
+  <form id="imageForm" class="mb-6 space-x-2">
+    <input type="text" id="imageUrlInput" placeholder="URL ảnh" class="border p-2 rounded" required>
+    <input type="text" id="descriptionInput" placeholder="Mô tả" class="border p-2 rounded">
+    <button type="submit" class="btn-primary">Thêm ảnh</button>
+  </form>
+
+  <table class="min-w-full bg-white rounded shadow">
+    <thead>
+      <tr class="bg-gray-100">
+        <th class="px-4 py-2 text-left">Ảnh</th>
+        <th class="px-4 py-2 text-left">Mô tả</th>
+        <th class="px-4 py-2">Hành động</th>
+      </tr>
+    </thead>
+    <tbody id="imageBody"></tbody>
+  </table>
+</div>
+
+<script>
+const params = new URLSearchParams(window.location.search);
+const productId = params.get('productId');
+if (!productId) {
+  document.body.innerHTML = '<p class="text-center text-red-500">Thiếu ID sản phẩm</p>';
+}
+
+async function loadProduct() {
+  const res = await fetch(`/product/${productId}`);
+  const product = await res.json();
+  document.getElementById('productName').textContent = product.name || productId;
+}
+
+async function loadImages() {
+  const res = await fetch(`/images?product_id=${encodeURIComponent(productId)}`);
+  const data = await res.json();
+  const tbody = document.getElementById('imageBody');
+  tbody.innerHTML = data.map(img => `
+    <tr class="border-b">
+      <td class="px-4 py-2"><img src="${img.url}" class="w-16 h-16 object-cover rounded" alt="img"></td>
+      <td class="px-4 py-2">${img.description || ''}</td>
+      <td class="px-4 py-2 space-x-2">
+        <button onclick="editImage('${img._id}')" class="btn-secondary btn-sm">Sửa</button>
+        <button onclick="deleteImage('${img._id}')" class="btn-danger btn-sm">Xóa</button>
+      </td>
+    </tr>
+  `).join('');
+}
+
+const form = document.getElementById('imageForm');
+if (form) {
+  form.addEventListener('submit', async (e) => {
+    e.preventDefault();
+    const url = document.getElementById('imageUrlInput').value.trim();
+    const description = document.getElementById('descriptionInput').value.trim();
+    await fetch('/images', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ url, product_id: productId, description })
+    });
+    e.target.reset();
+    loadImages();
+  });
+}
+
+async function editImage(id) {
+  const url = prompt('URL ảnh mới:');
+  if (!url) return;
+  const description = prompt('Mô tả:', '');
+  await fetch(`/images/${id}`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ url, description })
+  });
+  loadImages();
+}
+
+async function deleteImage(id) {
+  if (!confirm('Xóa ảnh này?')) return;
+  await fetch(`/images/${id}`, { method: 'DELETE' });
+  loadImages();
+}
+
+if (productId) {
+  loadProduct();
+  loadImages();
+}
+</script>
+


### PR DESCRIPTION
## Summary
- filter image list by product in `/images` endpoint
- provide per-product image management page with add/edit/delete
- link image manager from each product row instead of a global button

## Testing
- `npm test` *(fails: Missing script: "test")*
- `node --check routes/image.js`
- `node --check public/admin/static/js/admin.js`


------
https://chatgpt.com/codex/tasks/task_e_68a8a5dece348330b7e3965c6a3378ae

## Summary by Sourcery

Enable per-product image management by extending the images API with filtering and adding a dedicated admin UI for CRUD operations linked from each product row

New Features:
- Allow filtering images by product_id or category_id on the /images endpoint
- Add a new admin page for managing images of a specific product with create, edit, and delete actions
- Insert image manager links in the product list to navigate to the per-product image UI