### PR TITLE
Add product variant management in admin panel

### DIFF
--- a/public/admin/static/css/form.css
+++ b/public/admin/static/css/form.css
@@ -73,23 +73,6 @@ input[type="text"]:focus, select:focus, input[type="number"]:focus, textarea:foc
   flex: 1;
 }
 
-/* Variant styles */
-#variantsContainer .spec-item select {
-  flex: 1;
-}
-.variant-custom input {
-  flex: 1;
-}
-.variant-custom .variant-name {
-  max-width: 140px;
-}
-#addVariantBtn {
-  margin-top: 10px;
-  background: #f3f4f6;
-  color: #222;
-  border: 1px solid #d1d5db;
-}
-
 /* Footer Buttons */
 .modal-footer {
   display: flex;

--- a/public/admin/static/js/admin.js
+++ b/public/admin/static/js/admin.js
@@ -87,17 +87,24 @@ function renderProducts(products, append = false) {
 
   products.forEach(p => {
     const tr = document.createElement("tr");
+    const price = new Intl.NumberFormat("vi-VN", { style: "currency", currency: "VND" }).format(p.price || 0);
+    const stock = p.stock ?? 0;
+    const variantCount = Array.isArray(p.variants) ? p.variants.length : 0;
     tr.innerHTML = `
       <td><img src="${p.image}" class="product-img" alt="${p.name}"></td>
       <td>${p.name}</td>
-      <td>${new Intl.NumberFormat("vi-VN", { style: "currency", currency: "VND" }).format(p.price)}</td>
-      <td>${p.stock}</td>
+      <td>${price}</td>
+      <td>${stock}</td>
+      <td>${variantCount}</td>
        <td class="actions text-center">
            <a href="/admin/products/${p._id}/edit" class="inline-block mx-1 p-2 hover:bg-gray-100 rounded">
              <i class="bx bx-edit text-xl"></i>
            </a>
             <a href="/admin/product-image?productId=${encodeURIComponent(p._id)}" class="inline-block mx-1 p-2 hover:bg-gray-100 rounded">
               <i class="bx bx-image text-xl"></i>
+            </a>
+            <a href="/admin/variants?productId=${encodeURIComponent(p._id)}" class="inline-block mx-1 p-2 hover:bg-gray-100 rounded">
+              <i class="bx bx-layer text-xl"></i>
             </a>
            <a href="#" onclick="deleteProduct('${p._id}')" class="inline-block mx-1 p-2 hover:bg-gray-100 rounded">
              <i class="bx bx-trash text-xl"></i>
@@ -137,9 +144,6 @@ async function initProductForm() {
   const form = document.getElementById("productForm");
   const categorySelect = document.getElementById("categorySelect");
   const specContainer = document.getElementById("specContainer");
-  const variantsContainer = document.getElementById("variantsContainer");
-  const addVariantBtn = document.getElementById("addVariantBtn");
-  const variantsInput = document.getElementById("variantsInput");
   const descInput = document.getElementById("descriptionInput");
   const descEditorEl = document.getElementById("descriptionEditor");
   const imageFile = document.getElementById("imageFile");
@@ -150,7 +154,6 @@ async function initProductForm() {
   const imageFileGroup = document.getElementById("imageFileGroup");
   const imageLinkGroup = document.getElementById("imageLinkGroup");
   const priceInput = form.querySelector('input[name="price"]');
-  const stockInput = form.querySelector('input[name="stock"]');
 
   const getSpecInputs = () =>
     Array.from(specContainer.querySelectorAll(".spec-item input")).filter(
@@ -165,7 +168,6 @@ async function initProductForm() {
   }
 
   setupNumberInput(priceInput);
-  setupNumberInput(stockInput);
 
   // Initialize CKEditor
   try {
@@ -215,71 +217,10 @@ async function initProductForm() {
     if (hiddenId) form.dataset.id = hiddenId.value;
   }
 
-  function addVariantOption(container, label = '', priceDiff = 0) {
-    const row = document.createElement('div');
-    row.className = 'variant-option';
-    row.innerHTML = `
-      <input type="text" class="form-control variant-option-label" placeholder="Tên lựa chọn" value="${label}">
-      <input type="number" class="form-control variant-option-price" placeholder="Chênh lệch giá" value="${priceDiff}">
-      <button type="button" class="btn btn-sm btn-danger remove-option">&times;</button>`;
-    row.querySelector('.remove-option').addEventListener('click', () => row.remove());
-    container.appendChild(row);
-  }
-
-  function addVariantGroup(name = '', options = []) {
-    const group = document.createElement('div');
-    group.className = 'spec-item variant-group';
-    group.innerHTML = `
-      <input type="text" class="form-control variant-group-name" placeholder="Tên biến thể" value="${name}">
-      <div class="variant-options"></div>
-      <button type="button" class="btn btn-sm btn-secondary add-option">Thêm lựa chọn</button>
-      <button type="button" class="btn btn-sm btn-danger remove-group">&times;</button>`;
-
-    const optionsContainer = group.querySelector('.variant-options');
-    const addOptionBtn = group.querySelector('.add-option');
-    const removeGroupBtn = group.querySelector('.remove-group');
-
-    addOptionBtn.addEventListener('click', () => addVariantOption(optionsContainer));
-    removeGroupBtn.addEventListener('click', () => group.remove());
-
-    options.forEach(opt => addVariantOption(optionsContainer, opt.label || opt, opt.priceDiff || 0));
-
-    variantsContainer.appendChild(group);
-  }
-
-  function renderVariantOptions(templateList = [], existing = []) {
-    console.log('Rendering variant options:', templateList, existing);
-    variantsContainer.innerHTML = '';
-    const used = new Set();
-
-    templateList.forEach(opt => {
-      const key = opt.name || opt.key;
-      const match = Array.isArray(existing)
-        ? existing.find(g => (g.key || g.name) === key)
-        : null;
-      const options = match
-        ? (match.options || []).map(o => ({ label: o.label || o, priceDiff: o.priceDiff || 0 }))
-        : (opt.options || []).map(o => ({ label: o, priceDiff: 0 }));
-      addVariantGroup(key, options);
-      used.add(key);
-    });
-
-    if (Array.isArray(existing)) {
-      existing.forEach(g => {
-        const key = g.key || g.name;
-        if (!used.has(key)) {
-          const opts = (g.options || []).map(o => ({ label: o.label || o, priceDiff: o.priceDiff || 0 }));
-          addVariantGroup(key, opts);
-        }
-      });
-    }
-  }
-
-  async function loadSpecsAndVariants(catId, existingVariants = []) {
-    console.log('Loading specs and variants for category:', catId);
+  async function loadSpecs(catId) {
+    console.log('Loading specs for category:', catId);
 
     specContainer.innerHTML = '';
-    variantsContainer.innerHTML = '';
 
     if (!catId) {
       console.log('No category selected');
@@ -302,12 +243,10 @@ async function initProductForm() {
       console.log('Received data:', data);
 
       let specs = [];
-      let variantOpts = [];
 
       // Parse response data
       if (Array.isArray(data.specs)) {
         specs = data.specs;
-        variantOpts = Array.isArray(data.variantOptions) ? data.variantOptions : [];
       } else if (Array.isArray(data.fields)) {
         specs = data.fields; // ← Thêm dòng này để hỗ trợ `fields` thay vì `specs`
       } else if (Array.isArray(data)) {
@@ -317,12 +256,8 @@ async function initProductForm() {
         } else if (Array.isArray(first.value)) {
           specs = first.value;
         }
-        if (Array.isArray(first.variantOptions)) {
-          variantOpts = first.variantOptions;
-        }
       }
       console.log('Parsed specs:', specs);
-      console.log('Parsed variants:', variantOpts);
 
       // Render specification fields
       specs.forEach(fieldName => {
@@ -335,11 +270,8 @@ async function initProductForm() {
         specContainer.appendChild(div);
       });
 
-      // Render variant options
-      renderVariantOptions(variantOpts, existingVariants);
-
     } catch (err) {
-      console.error('Load specs/variants error:', err);
+      console.error('Load specs error:', err);
       showToast('Lỗi tải thông số kỹ thuật', 'error');
     }
   }
@@ -347,13 +279,8 @@ async function initProductForm() {
   // Category change event handler
   categorySelect.addEventListener('change', async (e) => {
     console.log('Category changed to:', e.target.value);
-    await loadSpecsAndVariants(e.target.value);
+    await loadSpecs(e.target.value);
   });
-
-  // Add variant button
-  if (addVariantBtn) {
-    addVariantBtn.addEventListener('click', () => addVariantGroup());
-  }
 
   // Preload form data in edit mode
   if (form.dataset.mode === "edit") {
@@ -370,7 +297,6 @@ async function initProductForm() {
         // Fill basic fields
         form.querySelector('input[name="name"]').value = prod.name || '';
         if (priceInput) { priceInput.value = prod.price || ''; priceInput.dispatchEvent(new Event('input')); }
-        if (stockInput) { stockInput.value = prod.stock || ''; stockInput.dispatchEvent(new Event('input')); }
         if (editor) editor.setData(prod.description || "");
         if (descInput) descInput.value = prod.description || '';
 
@@ -389,10 +315,7 @@ async function initProductForm() {
         if (prod.category_id && prod.category_id._id) {
           categorySelect.value = prod.category_id._id;
 
-          await loadSpecsAndVariants(
-            prod.category_id._id,
-            Array.isArray(prod.variants) ? prod.variants : []
-          );
+          await loadSpecs(prod.category_id._id);
 
           // Fill spec values
           const specList = Array.isArray(prod.tskt) ? prod.tskt : prod.specifications || [];
@@ -412,7 +335,7 @@ async function initProductForm() {
   } else if (categorySelect.value) {
     // Load specs for initially selected category in create mode
     console.log('Loading specs for initial category:', categorySelect.value);
-    await loadSpecsAndVariants(categorySelect.value);
+    await loadSpecs(categorySelect.value);
   }
 
   // Form submit handler
@@ -447,32 +370,13 @@ async function initProductForm() {
         }
       }
 
-      // Collect variant data with price differences
-      const variantsArray = [];
-      variantsContainer.querySelectorAll('.variant-group').forEach(group => {
-        const key = group.querySelector('.variant-group-name').value.trim();
-        const options = [];
-        group.querySelectorAll('.variant-option').forEach(opt => {
-          const label = opt.querySelector('.variant-option-label').value.trim();
-          const priceDiff = parseFloat(opt.querySelector('.variant-option-price').value) || 0;
-          if (label) options.push({ label, priceDiff });
-        });
-        if (key && options.length) {
-          variantsArray.push({ key, options });
-        }
-      });
-
-      variantsInput.value = JSON.stringify(variantsArray);
-
-      
-
       // Prepare payload
       const payload = {
         name: fd.get("name"),
         category_id: fd.get("category_id"),
         brand_id: fd.get("brand_id"),
         price: Number(String(fd.get("price")).replace(/[^0-9]/g, '')),
-        stock: Number(String(fd.get("stock")).replace(/[^0-9]/g, '')),
+        stock: 0,
         image: imageUrl,
         description: fd.get("description"),
         specifications: getSpecInputs()
@@ -481,8 +385,7 @@ async function initProductForm() {
             value: inp.value
           }))
           .filter(item => item.key && item.value.trim()),
-        // Mặc định gửi '[]' nếu không có variants
-        variants: variantsInput.value
+        variants: []
       };
 
       const url = fd.get("id") ? `${apiProduct}/${fd.get("id")}` : apiProduct;

--- a/routes/admin.js
+++ b/routes/admin.js
@@ -10,6 +10,7 @@ const Video = require('../models/Video');
 const Combo = require('../models/Combo');
 const Image = require('../models/Image');
 const Order = require('../models/Order');
+const VariantProduct = require('../models/Variantproduct');
 
 // Dashboard
 router.get('/dashboard', async (req, res) => {
@@ -274,6 +275,32 @@ router.get('/preset-build', (req, res) => {
 // Quản lý voucher
 router.get('/vouchers', (req, res) => {
   res.render('admin/vouchers', { layout: 'admin/layout' });
+});
+
+// Quản lý biến thể sản phẩm
+router.get('/variants', (req, res) => {
+  res.render('admin/variants', { layout: 'admin/layout' });
+});
+
+router.get('/variants/create', async (req, res) => {
+  const products = await Product.find().select('name').lean();
+  res.render('admin/variant-form', {
+    layout: 'admin/layout',
+    variant: {},
+    products
+  });
+});
+
+router.get('/variants/:id/edit', async (req, res) => {
+  const [variant, products] = await Promise.all([
+    VariantProduct.findById(req.params.id).lean(),
+    Product.find().select('name').lean()
+  ]);
+  res.render('admin/variant-form', {
+    layout: 'admin/layout',
+    variant,
+    products
+  });
 });
 
 module.exports = router;

--- a/routes/variant.js
+++ b/routes/variant.js
@@ -1,14 +1,13 @@
 const express = require('express');
 const router = express.Router();
-const VariantProduct = require('../models/Variantproduct');
 const mongoose = require('mongoose');
+const VariantProduct = require('../models/Variantproduct');
 
 // Tạo mới một biến thể sản phẩm
 router.post('/create', async (req, res) => {
   try {
-    const { product_id, order_id, name, price, stock, image } = req.body;
+    const { product_id, name, price, stock } = req.body;
 
-    // Kiểm tra product_id hợp lệ
     if (!mongoose.Types.ObjectId.isValid(product_id)) {
       return res.status(400).json({ error: 'product_id không hợp lệ' });
     }
@@ -27,6 +26,18 @@ router.post('/create', async (req, res) => {
   }
 });
 
+// Lấy tất cả biến thể
+router.get('/', async (req, res) => {
+  try {
+    const variants = await VariantProduct.find()
+      .populate('product_id', 'name')
+      .lean();
+    res.json(variants);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
 // Lấy danh sách biến thể theo productId
 router.get('/by-product/:productId', async (req, res) => {
   try {
@@ -34,11 +45,52 @@ router.get('/by-product/:productId', async (req, res) => {
     if (!mongoose.Types.ObjectId.isValid(productId)) {
       return res.status(400).json({ error: 'productId không hợp lệ' });
     }
-    const variants = await VariantProduct.find({ product_id: productId });
+    const variants = await VariantProduct.find({ product_id: productId })
+      .populate('product_id', 'name')
+      .lean();
     res.json(variants);
   } catch (err) {
     res.status(500).json({ error: err.message });
   }
 });
 
+// Lấy biến thể theo id
+router.get('/:id', async (req, res) => {
+  try {
+    const variant = await VariantProduct.findById(req.params.id);
+    if (!variant) return res.status(404).json({ error: 'Không tìm thấy biến thể' });
+    res.json(variant);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+// Cập nhật biến thể
+router.put('/:id', async (req, res) => {
+  try {
+    const { name, price, stock, product_id } = req.body;
+    const update = { name, price, stock };
+    if (product_id && mongoose.Types.ObjectId.isValid(product_id)) {
+      update.product_id = product_id;
+    }
+    const variant = await VariantProduct.findByIdAndUpdate(req.params.id, update, { new: true });
+    if (!variant) return res.status(404).json({ error: 'Không tìm thấy biến thể' });
+    res.json({ message: 'Cập nhật thành công', variant });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+// Xóa biến thể
+router.delete('/:id', async (req, res) => {
+  try {
+    const variant = await VariantProduct.findByIdAndDelete(req.params.id);
+    if (!variant) return res.status(404).json({ error: 'Không tìm thấy biến thể' });
+    res.json({ message: 'Đã xóa biến thể' });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
 module.exports = router;
+

--- a/views/admin/form.hbs
+++ b/views/admin/form.hbs
@@ -48,29 +48,15 @@
         <label>Giá (VNĐ) *</label>
         <input type="text" name="price" value="{{product.price}}" placeholder="Nhập giá sản phẩm" required class="number-input">
       </div>
-
-      <div class="form-group">
-        <label>Số lượng *</label>
-        <input type="text" name="stock" value="{{product.stock}}" placeholder="Nhập số lượng" required class="number-input">
-      </div>
     </div>
 
     <div class="form-section">
-      <h3>Thông số & Biến thể</h3>
+      <h3>Thông số</h3>
       <div class="form-group">
         <label>Thông số kỹ thuật</label>
         <div id="specContainer">
           <!-- Specs will be loaded dynamically based on category -->
         </div>
-      </div>
-
-      <div class="form-group">
-        <label>Biến thể</label>
-        <div id="variantsContainer">
-          <!-- Variants will be loaded dynamically based on category -->
-        </div>
-        <button type="button" class="btn btn-sm btn-secondary" id="addVariantBtn">Thêm nhóm biến thể</button>
-        <input type="hidden" id="variantsInput" name="variants" value="[]">
       </div>
     </div>
 

--- a/views/admin/products.hbs
+++ b/views/admin/products.hbs
@@ -12,6 +12,7 @@
       <th>Tên</th>
       <th>Giá</th>
       <th>Kho</th>
+      <th>Biến thể</th>
       <th>Hành động</th>
     </tr>
   </thead>

--- a/views/admin/variant-form.hbs
+++ b/views/admin/variant-form.hbs
@@ -1,0 +1,88 @@
+{{#*inline "title"}}
+  {{#if variant._id}}Chỉnh sửa Biến thể{{else}}Tạo Biến thể{{/if}}
+{{/inline}}
+
+<link rel="stylesheet" href="/admin/static/css/form.css" />
+
+<div class="form-scroll-container">
+  <form id="variantForm" {{#if variant._id}}data-id="{{variant._id}}"{{/if}}>
+    {{#if variant._id}}
+      <input type="hidden" name="id" value="{{variant._id}}" />
+    {{/if}}
+
+    <div class="form-section">
+      <h3>Thông tin biến thể</h3>
+
+      <div class="form-group">
+        <label>Sản phẩm *</label>
+        <select name="product_id" required>
+          <option value="">-- Chọn sản phẩm --</option>
+          {{#each products}}
+            <option value="{{_id}}" {{#ifEquals _id ../variant.product_id}}selected{{/ifEquals}}>
+              {{name}}
+            </option>
+          {{/each}}
+        </select>
+      </div>
+
+      <div class="form-group">
+        <label>Tên biến thể *</label>
+        <input type="text" name="name" value="{{variant.name}}" required />
+      </div>
+
+      <div class="form-group">
+        <label>Giá (VNĐ) *</label>
+        <input type="number" name="price" value="{{variant.price}}" min="0" required />
+      </div>
+
+      <div class="form-group">
+        <label>Số lượng tồn kho *</label>
+        <input type="number" name="stock" value="{{variant.stock}}" min="0" required />
+      </div>
+    </div>
+
+    <div class="form-actions">
+      <button type="submit" class="btn-primary">Lưu</button>
+    </div>
+  </form>
+</div>
+
+<script>
+  document.addEventListener('DOMContentLoaded', () => {
+    const params = new URLSearchParams(window.location.search);
+    const productId = params.get('productId');
+    if (productId) {
+      const select = document.querySelector('select[name="product_id"]');
+      if (select && !select.value) select.value = productId;
+    }
+    document.getElementById('variantForm').addEventListener('submit', async function (e) {
+      e.preventDefault();
+      const fd = new FormData(this);
+      const id = fd.get('id');
+      const payload = {
+        product_id: fd.get('product_id'),
+        name: fd.get('name'),
+        price: Number(fd.get('price')),
+        stock: Number(fd.get('stock'))
+      };
+      const url = id ? `/variants/${id}` : '/variants/create';
+      const method = id ? 'PUT' : 'POST';
+      try {
+        const res = await fetch(url, {
+          method,
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(payload)
+        });
+        if (!res.ok) {
+          const data = await res.json().catch(() => ({}));
+          alert(data.error || 'Có lỗi xảy ra');
+          return;
+        }
+        window.location.href = productId ? `/admin/variants?productId=${productId}` : '/admin/variants';
+      } catch (err) {
+        alert('Lỗi: ' + err.message);
+      }
+    });
+  });
+</script>
+

--- a/views/admin/variants.hbs
+++ b/views/admin/variants.hbs
@@ -1,0 +1,100 @@
+{{#*inline "title"}}Quản lý Biến thể{{/inline}}
+
+<link rel="stylesheet" href="/admin/static/css/user.css" />
+
+<div class="container glass-card rounded-2xl p-6 fade-in">
+  <div class="header-actions mb-4 flex justify-between items-center">
+    <a id="addVariantLink" href="/admin/variants/create" class="btn-add-user">
+      <span class="icon"><i class="bx bx-plus"></i></span>
+      <span>Thêm Biến thể</span>
+    </a>
+    <input
+      type="text"
+      id="variantSearch"
+      placeholder="Tìm kiếm theo tên..."
+      class="search-input w-1/3 px-4 py-2 rounded"
+    />
+  </div>
+</div>
+
+<div class="table-container overflow-auto shadow rounded">
+  <table class="min-w-full divide-y divide-gray-200 bg-white">
+    <thead class="bg-gray-50">
+      <tr>
+        <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">Sản phẩm</th>
+        <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">Tên biến thể</th>
+        <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">Giá</th>
+        <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">Tồn kho</th>
+        <th class="px-6 py-3 text-center text-xs font-medium text-gray-500 uppercase">Hành động</th>
+      </tr>
+    </thead>
+    <tbody id="variantTable" class="bg-white divide-y divide-gray-200"></tbody>
+  </table>
+</div>
+
+<script>
+  let allVariants = [];
+  let currentProductId = null;
+
+  async function fetchVariants(productId) {
+    try {
+      currentProductId = productId || null;
+      const url = productId ? `/variants/by-product/${productId}` : '/variants';
+      const res = await fetch(url);
+      if (!res.ok) throw new Error('Lỗi tải dữ liệu');
+      allVariants = await res.json();
+      renderVariants(allVariants);
+    } catch (err) {
+      console.error(err);
+    }
+  }
+
+  function renderVariants(list) {
+    const tbody = document.getElementById('variantTable');
+    tbody.innerHTML = '';
+    list.forEach(v => {
+      const tr = document.createElement('tr');
+      const price = new Intl.NumberFormat('vi-VN', { style: 'currency', currency: 'VND' }).format(v.price || 0);
+      tr.innerHTML = `
+        <td class="px-6 py-4">${v.product_id ? v.product_id.name : ''}</td>
+        <td class="px-6 py-4">${v.name}</td>
+        <td class="px-6 py-4">${price}</td>
+        <td class="px-6 py-4">${v.stock ?? 0}</td>
+        <td class="px-6 py-4 text-center">
+          <a href="/admin/variants/${v._id}/edit" class="inline-block mx-1 p-2 hover:bg-gray-100 rounded">
+            <i class="bx bx-edit text-xl"></i>
+          </a>
+          <a href="#" onclick="deleteVariant('${v._id}')" class="inline-block mx-1 p-2 hover:bg-gray-100 rounded">
+            <i class="bx bx-trash text-xl"></i>
+          </a>
+        </td>`;
+      tbody.appendChild(tr);
+    });
+  }
+
+  async function deleteVariant(id) {
+    if (!confirm('Bạn có chắc muốn xóa biến thể này?')) return;
+    try {
+      const res = await fetch('/variants/' + id, { method: 'DELETE' });
+      if (!res.ok) throw new Error('Xóa thất bại');
+      fetchVariants(currentProductId);
+    } catch (err) {
+      alert('Lỗi: ' + err.message);
+    }
+  }
+
+  document.addEventListener('DOMContentLoaded', () => {
+    const params = new URLSearchParams(window.location.search);
+    const productId = params.get('productId');
+    if (productId) {
+      const link = document.getElementById('addVariantLink');
+      if (link) link.href = `/admin/variants/create?productId=${productId}`;
+    }
+    fetchVariants(productId);
+    document.getElementById('variantSearch').addEventListener('input', e => {
+      const q = e.target.value.toLowerCase();
+      renderVariants(allVariants.filter(v => v.name.toLowerCase().includes(q)));
+    });
+  });
+</script>
+


### PR DESCRIPTION
## Summary
- Implement full CRUD endpoints for product variants
- Add admin pages for listing and editing product variants
- Enable product-specific variant management from the product list
- Populate product name and format variant prices
- Show product stock and variant counts in admin listings
- Remove stock and inline variant controls from the product form, delegating inventory to the variant manager

## Testing
- `npm test` *(fails: Missing script "test")*
- `node --check public/admin/static/js/admin.js`

------
https://chatgpt.com/codex/tasks/task_e_68ab25829b2c8330b2723b6c42ea130a