### PR TITLE
Add admin brand management page with CRUD

### DIFF
--- a/routes/admin.js
+++ b/routes/admin.js
@@ -90,6 +90,11 @@ router.get('/categories/edit/:id', async (req, res) => {
   res.render('admin/category-form', { category });
 });
 
+// Quản lý thương hiệu
+router.get('/brands', (req, res) => {
+  res.render('admin/brand', { layout: 'admin/layout' });
+});
+
 // bao cao
 router.get('/reports', (req, res) => {
   res.render('admin/baocao', { layout: 'admin/layout' });

--- a/views/admin/brand.hbs
+++ b/views/admin/brand.hbs
@@ -1,0 +1,75 @@
+{{#*inline "title"}}Quản lý thương hiệu{{/inline}}
+
+<div class="max-w-4xl mx-auto p-6">
+  <h1 class="text-2xl font-bold mb-4">Quản lý thương hiệu</h1>
+  <form id="createForm" class="mb-6 flex flex-col md:flex-row gap-2">
+    <input id="brandName" type="text" placeholder="Tên thương hiệu" class="border p-2 rounded flex-1" required>
+    <input id="brandLogo" type="text" placeholder="Logo URL" class="border p-2 rounded flex-1">
+    <button type="submit" class="bg-blue-500 text-white px-4 py-2 rounded">Thêm</button>
+  </form>
+  <table class="min-w-full bg-white rounded shadow">
+    <thead>
+      <tr>
+        <th class="py-2 px-4 border-b">Tên</th>
+        <th class="py-2 px-4 border-b">Logo</th>
+        <th class="py-2 px-4 border-b text-center">Hành động</th>
+      </tr>
+    </thead>
+    <tbody id="brandsTable"></tbody>
+  </table>
+</div>
+
+<script>
+  async function fetchBrands() {
+    const res = await fetch('/brands');
+    const data = await res.json();
+    const tbody = document.getElementById('brandsTable');
+    tbody.innerHTML = '';
+    data.forEach(b => {
+      const tr = document.createElement('tr');
+      tr.innerHTML = `
+        <td class="border-b px-4 py-2">${b.name}</td>
+        <td class="border-b px-4 py-2">${b.logo ? `<img src="${b.logo}" class="h-8">` : ''}</td>
+        <td class="border-b px-4 py-2 text-center space-x-2">
+          <button onclick="editBrand('${b._id}', '${b.name}', '${b.logo || ''}')" class="text-blue-500"><i class="fas fa-edit"></i></button>
+          <button onclick="deleteBrand('${b._id}')" class="text-red-500"><i class="fas fa-trash"></i></button>
+        </td>
+      `;
+      tbody.appendChild(tr);
+    });
+  }
+
+  document.getElementById('createForm').addEventListener('submit', async (e) => {
+    e.preventDefault();
+    const name = document.getElementById('brandName').value.trim();
+    const logo = document.getElementById('brandLogo').value.trim();
+    if(!name) return;
+    await fetch('/brands', {
+      method:'POST',
+      headers:{'Content-Type':'application/json'},
+      body: JSON.stringify({ name, logo })
+    });
+    e.target.reset();
+    fetchBrands();
+  });
+
+  async function editBrand(id, name, logo) {
+    const newName = prompt('Tên thương hiệu', name);
+    if(newName === null) return;
+    const newLogo = prompt('Logo URL', logo);
+    await fetch('/brands/' + id, {
+      method:'PUT',
+      headers:{'Content-Type':'application/json'},
+      body: JSON.stringify({ name:newName, logo:newLogo })
+    });
+    fetchBrands();
+  }
+
+  async function deleteBrand(id) {
+    if(!confirm('Xóa thương hiệu này?')) return;
+    await fetch('/brands/' + id, { method:'DELETE' });
+    fetchBrands();
+  }
+
+  document.addEventListener('DOMContentLoaded', fetchBrands);
+</script>

--- a/views/admin/index.hbs
+++ b/views/admin/index.hbs
@@ -24,6 +24,12 @@
         <a href="/admin/categories" title="Quản lý danh mục"></a>
     </div>
     <div class="card animate__animated animate__fadeInUp">
+        <i class="fas fa-industry"></i>
+        <h3>Quản lý thương hiệu</h3>
+        <p>Thêm, sửa, xóa thương hiệu sản phẩm.</p>
+        <a href="/admin/brands" title="Quản lý thương hiệu"></a>
+    </div>
+    <div class="card animate__animated animate__fadeInUp">
         <i class="fas fa-shopping-cart"></i>
         <h3>Quản lý đơn hàng</h3>
         <p>Xem đơn hàng, cập nhật trạng thái và xử lý vận chuyển.</p>


### PR DESCRIPTION
## Summary
- link new brand management page from dashboard
- implement brand CRUD interface using existing API
- add server route to render brand page

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68ab4a8ef6188330bff52a365aa816df

## Summary by Sourcery

Introduce brand management functionality in the admin panel with full CRUD support

New Features:
- Add brand management card to the admin dashboard linking to /admin/brands
- Register admin route to render the brand management page
- Create brand management page with form, table, and AJAX-based create, read, update, and delete operations