### PR TITLE
feat: expand sales report options

### DIFF
--- a/controllers/reportCtrl.js
+++ b/controllers/reportCtrl.js
@@ -1,5 +1,7 @@
 // controllers/reportCtrl.js
 const Order = require('../models/Order');  // đúng đường dẫn đến model
+// Thêm các model khác nếu cần thiết cho việc thống kê
+// (sử dụng tên collection trong pipeline $lookup nên không bắt buộc import)
 
 // 1. Tổng hợp doanh thu, số đơn, doanh thu trung bình
 exports.getSummary = async (req, res) => {
@@ -174,6 +176,133 @@ exports.getRevenue = async (req, res) => {
     res.json({ labels, data });
   } catch (err) {
     console.error('Error in getRevenue:', err);
+    res.status(500).json({ error: err.message });
+  }
+};
+
+// Thống kê sản phẩm theo danh mục
+exports.getProductsByCategory = async (req, res) => {
+  try {
+    const agg = await Order.aggregate([
+      { $match: { status: 'delivered' } },
+      { $unwind: '$products' },
+      {
+        $group: {
+          _id: '$products.productId',
+          qty: { $sum: '$products.quantity' }
+        }
+      },
+      {
+        $lookup: {
+          from: 'products',
+          localField: '_id',
+          foreignField: '_id',
+          as: 'prod'
+        }
+      },
+      { $unwind: '$prod' },
+      {
+        $group: {
+          _id: '$prod.category_id',
+          total: { $sum: '$qty' }
+        }
+      },
+      {
+        $lookup: {
+          from: 'categories',
+          localField: '_id',
+          foreignField: '_id',
+          as: 'cat'
+        }
+      },
+      { $unwind: '$cat' },
+      {
+        $project: {
+          _id: '$cat.name',
+          total: 1
+        }
+      },
+      { $sort: { total: -1 } }
+    ]);
+
+    const labels = agg.map(a => a._id);
+    const data = agg.map(a => a.total);
+    res.json({ labels, data });
+  } catch (err) {
+    console.error('Error in getProductsByCategory:', err);
+    res.status(500).json({ error: err.message });
+  }
+};
+
+// Sản phẩm bán chạy
+exports.getBestSellers = async (req, res) => {
+  try {
+    const agg = await Order.aggregate([
+      { $match: { status: 'delivered' } },
+      { $unwind: '$products' },
+      {
+        $group: {
+          _id: '$products.productId',
+          total: { $sum: '$products.quantity' }
+        }
+      },
+      {
+        $lookup: {
+          from: 'products',
+          localField: '_id',
+          foreignField: '_id',
+          as: 'prod'
+        }
+      },
+      { $unwind: '$prod' },
+      { $sort: { total: -1 } },
+      { $limit: 5 }
+    ]);
+
+    const labels = agg.map(a => a.prod.name);
+    const data = agg.map(a => a.total);
+    res.json({ labels, data });
+  } catch (err) {
+    console.error('Error in getBestSellers:', err);
+    res.status(500).json({ error: err.message });
+  }
+};
+
+// Người mua nhiều nhất
+exports.getTopBuyers = async (req, res) => {
+  try {
+    const agg = await Order.aggregate([
+      { $match: { status: 'delivered', user_id: { $ne: null } } },
+      {
+        $group: {
+          _id: '$user_id',
+          total: { $sum: '$total' }
+        }
+      },
+      {
+        $lookup: {
+          from: 'users',
+          localField: '_id',
+          foreignField: '_id',
+          as: 'user'
+        }
+      },
+      { $unwind: '$user' },
+      { $sort: { total: -1 } },
+      { $limit: 5 },
+      {
+        $project: {
+          name: '$user.full_name',
+          total: 1
+        }
+      }
+    ]);
+
+    const labels = agg.map(a => a.name);
+    const data = agg.map(a => a.total);
+    res.json({ labels, data });
+  } catch (err) {
+    console.error('Error in getTopBuyers:', err);
     res.status(500).json({ error: err.message });
   }
 };

--- a/public/admin/static/js/baocao.js
+++ b/public/admin/static/js/baocao.js
@@ -28,6 +28,7 @@ document.addEventListener('DOMContentLoaded', async () => {
       const revenue = await revRes.json();
       animateSummary(summary);
       renderRevenueChart(revenue);
+      setTableHeader('Thời gian', 'Doanh thu');
       fillTable(revenue);
     } else {
       console.error('Fetch error', sumRes.status, revRes.status);
@@ -41,6 +42,7 @@ document.addEventListener('DOMContentLoaded', async () => {
   populateMonthSelectors();
   initInputs();
   document.getElementById('periodSelect')?.addEventListener('change', updateInputs);
+  document.getElementById('reportType')?.addEventListener('change', updateInputs);
   document.getElementById('loadRevenue')?.addEventListener('click', loadRevenueData);
   document.getElementById('compareBtn')?.addEventListener('click', compareMonths);
 });
@@ -89,6 +91,29 @@ function renderLineChart(labels, datasets) {
   });
 }
 
+function renderBarChart(labels, label, data, currency = false) {
+  const ctx = document.getElementById('revenueChart').getContext('2d');
+  if (revenueChart) revenueChart.destroy();
+  revenueChart = new Chart(ctx, {
+    type: 'bar',
+    data: { labels, datasets: [{
+      label,
+      data,
+      backgroundColor: hexToRgba(chartColors[1], 0.6)
+    }] },
+    options: {
+      responsive: true,
+      scales: {
+        y: {
+          beginAtZero: true,
+          ticks: currency ? { callback: fmtCur } : {}
+        },
+        x: { grid: { display: false } }
+      }
+    }
+  });
+}
+
 function renderRevenueChart(data) {
   renderLineChart(data.labels, [{
     label: 'Doanh thu',
@@ -103,20 +128,45 @@ function renderRevenueChart(data) {
 }
 
 // -------- Bảng chi tiết --------
-function fillTable(data) {
+function setTableHeader(c1, c2) {
+  const tr = document.querySelector('#tableModal thead tr');
+  if (tr) tr.innerHTML = `<th>${c1}</th><th class="text-end">${c2}</th>`;
+}
+
+function fillTable(data, currency = true) {
   const tbody = document.getElementById('revenueTable');
   if (!tbody) return;
   tbody.innerHTML = '';
   data.labels.forEach((lbl, idx) => {
+    const val = currency ? fmtCur(data.data[idx]) : data.data[idx];
     const tr = document.createElement('tr');
     tr.innerHTML = `<td><strong>${lbl}</strong></td>` +
-                   `<td class="text-end"><strong>${fmtCur(data.data[idx])}</strong></td>`;
+                   `<td class="text-end"><strong>${val}</strong></td>`;
     tbody.appendChild(tr);
   });
 }
 
 // -------- Bộ lọc --------
 function updateInputs() {
+  const reportType = document.getElementById('reportType')?.value;
+  const periodRow = document.getElementById('periodRow');
+  const timeRow = document.getElementById('timeRow');
+  const compareSection = document.getElementById('compareSection');
+  const detailBtn = document.getElementById('detailBtn');
+
+  if (reportType !== 'revenue') {
+    periodRow?.classList.add('d-none');
+    timeRow?.classList.add('d-none');
+    compareSection?.classList.add('d-none');
+    detailBtn?.classList.add('d-none');
+    return;
+  }
+
+  periodRow?.classList.remove('d-none');
+  timeRow?.classList.remove('d-none');
+  compareSection?.classList.remove('d-none');
+  detailBtn?.classList.remove('d-none');
+
   const period = document.getElementById('periodSelect')?.value;
   const monthInput = document.getElementById('monthInput');
   const weekInput  = document.getElementById('weekInput');
@@ -155,27 +205,53 @@ async function loadRevenueData() {
   const spinner = document.getElementById('loadingSpinner');
   if (spinner) spinner.style.display = 'flex';
 
-  const period = document.getElementById('periodSelect')?.value;
-  let query = '';
-  if (period === 'month') {
-    const m = document.getElementById('monthInput').value;
-    if (!m) return;
-    query = `period=month&month=${m}`;
-  } else if (period === 'week') {
-    const w = document.getElementById('weekInput').value;
-    if (!w) return;
-    query = `period=week&week=${w}`;
-  } else {
-    const y = document.getElementById('yearInput').value;
-    if (!y) return;
-    query = `period=year&year=${y}`;
-  }
+  const reportType = document.getElementById('reportType')?.value || 'revenue';
+
   try {
-    const res = await fetch(`/reports/revenue?${query}`);
-    if (!res.ok) return console.error('fetch revenue error', res.status);
-    const data = await res.json();
-    renderRevenueChart(data);
-    fillTable(data);
+    if (reportType === 'revenue') {
+      const period = document.getElementById('periodSelect')?.value;
+      let query = '';
+      if (period === 'month') {
+        const m = document.getElementById('monthInput').value;
+        if (!m) return;
+        query = `period=month&month=${m}`;
+      } else if (period === 'week') {
+        const w = document.getElementById('weekInput').value;
+        if (!w) return;
+        query = `period=week&week=${w}`;
+      } else {
+        const y = document.getElementById('yearInput').value;
+        if (!y) return;
+        query = `period=year&year=${y}`;
+      }
+      const res = await fetch(`/reports/revenue?${query}`);
+      if (!res.ok) return console.error('fetch revenue error', res.status);
+      const data = await res.json();
+      renderRevenueChart(data);
+      setTableHeader('Thời gian', 'Doanh thu');
+      fillTable(data, true);
+    } else if (reportType === 'category') {
+      const res = await fetch('/reports/category');
+      if (!res.ok) return console.error('fetch category error', res.status);
+      const data = await res.json();
+      renderBarChart(data.labels, 'Số lượng', data.data);
+      setTableHeader('Danh mục', 'Số lượng');
+      fillTable(data, false);
+    } else if (reportType === 'best-sellers') {
+      const res = await fetch('/reports/best-sellers');
+      if (!res.ok) return console.error('fetch best sellers error', res.status);
+      const data = await res.json();
+      renderBarChart(data.labels, 'Số lượng', data.data);
+      setTableHeader('Sản phẩm', 'Số lượng');
+      fillTable(data, false);
+    } else if (reportType === 'top-buyers') {
+      const res = await fetch('/reports/top-buyers');
+      if (!res.ok) return console.error('fetch top buyers error', res.status);
+      const data = await res.json();
+      renderBarChart(data.labels, 'Doanh thu', data.data, true);
+      setTableHeader('Người mua', 'Doanh thu');
+      fillTable(data, true);
+    }
   } catch (err) {
     console.error('loadRevenueData error', err);
   } finally {

--- a/routes/reports.js
+++ b/routes/reports.js
@@ -6,5 +6,8 @@ router.get('/summary', reportCtrl.getSummary);
 router.get('/monthly', reportCtrl.getMonthlyRevenue);
 router.get('/compare', reportCtrl.compareMonths);
 router.get('/revenue', reportCtrl.getRevenue);
+router.get('/category', reportCtrl.getProductsByCategory);
+router.get('/best-sellers', reportCtrl.getBestSellers);
+router.get('/top-buyers', reportCtrl.getTopBuyers);
 
 module.exports = router;

--- a/views/admin/baocao.hbs
+++ b/views/admin/baocao.hbs
@@ -202,6 +202,12 @@
         flex: 1 1 45%;
         min-width: 140px;
     }
+    .comparison-header {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        cursor: pointer;
+    }
     .modal-content {
         border-radius: 1.5rem;
         box-shadow: 0 8px 32px 0 rgba(161,140,209,0.13);
@@ -302,6 +308,15 @@
                 </h3>
                 <div class="row g-3 align-items-end controls-row">
                     <div class="col-md-12">
+                        <label class="form-label fw-semibold">Tùy chọn báo cáo</label>
+                        <select id="reportType" class="form-select">
+                            <option value="revenue" selected>Doanh thu</option>
+                            <option value="category">Thống kê sản phẩm theo danh mục</option>
+                            <option value="best-sellers">Sản phẩm bán chạy</option>
+                            <option value="top-buyers">Người mua nhiều nhất</option>
+                        </select>
+                    </div>
+                    <div class="col-md-12" id="periodRow">
                         <label class="form-label fw-semibold">Loại thống kê</label>
                         <select id="periodSelect" class="form-select">
                             <option value="month" selected>Theo tháng</option>
@@ -309,7 +324,7 @@
                             <option value="year">Theo năm</option>
                         </select>
                     </div>
-                    <div class="col-md-12">
+                    <div class="col-md-12" id="timeRow">
                         <label class="form-label fw-semibold">Chọn thời gian</label>
                         <input type="month" id="monthInput" class="form-control" />
                         <input type="week" id="weekInput" class="form-control d-none" />
@@ -320,37 +335,42 @@
                             <i class="fas fa-search me-2"></i>
                             Xem báo cáo
                         </button>
-                        <button type="button" class="btn btn-primary w-100 mt-3 animate__animated animate__pulse" data-bs-toggle="modal" data-bs-target="#tableModal">
+                        <button id="detailBtn" type="button" class="btn btn-primary w-100 mt-3 animate__animated animate__pulse" data-bs-toggle="modal" data-bs-target="#tableModal">
                     <i class="fas fa-table me-2"></i>
                     Xem bảng chi tiết
                 </button>
                     </div>
-                    
+
                 </div>
             </section>
-            <section class="controls-section mt-3" data-aos="fade-up" data-aos-delay="200">
-                <h3 class="controls-title">
-                    <i class="fas fa-balance-scale"></i>
-                    So sánh doanh thu
-                </h3>
-                <div class="comparison-controls">
-                    <div>
-                        <label class="form-label fw-semibold">Tháng thứ nhất</label>
-                        <select id="month1" class="form-select" aria-label="Tháng so sánh 1">
-                            <option value="">Chọn tháng...</option>
-                        </select>
-                    </div>
-                    <div>
-                        <label class="form-label fw-semibold">Tháng thứ hai</label>
-                        <select id="month2" class="form-select" aria-label="Tháng so sánh 2">
-                            <option value="">Chọn tháng...</option>
-                        </select>
-                    </div>
-                    <div>
-                        <button id="compareBtn" class="btn btn-primary w-100 animate__animated animate__pulse">
-                            <i class="fas fa-chart-line me-2"></i>
-                            So sánh
-                        </button>
+            <section id="compareSection" class="controls-section mt-3" data-aos="fade-up" data-aos-delay="200">
+                <div class="comparison-header" data-bs-toggle="collapse" data-bs-target="#compareContent" aria-expanded="false" aria-controls="compareContent">
+                    <h3 class="controls-title mb-0">
+                        <i class="fas fa-balance-scale"></i>
+                        So sánh doanh thu
+                    </h3>
+                    <i class="fas fa-chevron-down"></i>
+                </div>
+                <div id="compareContent" class="collapse">
+                    <div class="comparison-controls">
+                        <div>
+                            <label class="form-label fw-semibold">Tháng thứ nhất</label>
+                            <select id="month1" class="form-select" aria-label="Tháng so sánh 1">
+                                <option value="">Chọn tháng...</option>
+                            </select>
+                        </div>
+                        <div>
+                            <label class="form-label fw-semibold">Tháng thứ hai</label>
+                            <select id="month2" class="form-select" aria-label="Tháng so sánh 2">
+                                <option value="">Chọn tháng...</option>
+                            </select>
+                        </div>
+                        <div>
+                            <button id="compareBtn" class="btn btn-primary w-100 animate__animated animate__pulse">
+                                <i class="fas fa-chart-line me-2"></i>
+                                So sánh
+                            </button>
+                        </div>
                     </div>
                 </div>
             </section>


### PR DESCRIPTION
## Summary
- fix category aggregation to return full dataset
- hide detail table when viewing non-revenue reports
- add collapsible monthly comparison panel for revenue reports

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68ab58d803a8833087e866fb0f1e1294