### PR TITLE
fix: center voucher dialog above layout

### DIFF
--- a/views/admin/vouchers.hbs
+++ b/views/admin/vouchers.hbs
@@ -226,7 +226,7 @@
             display: flex;
             justify-content: center;
             align-items: center;
-            z-index: 1000;
+            z-index: 10000;
             opacity: 0;
             visibility: hidden;
             transition: all 0.3s cubic-bezier(0.23, 1, 0.320, 1);
@@ -246,12 +246,15 @@
             max-height: 90vh;
             overflow-y: auto;
             box-shadow: 0 25px 50px rgba(0, 0, 0, 0.25);
-            transform: scale(0.8) translateY(20px);
+            position: absolute;
+            top: 50%;
+            left: 50%;
+            transform: translate(-50%, -50%) scale(0.8);
             transition: all 0.3s cubic-bezier(0.23, 1, 0.320, 1);
         }
 
         .modal-overlay.show .modal {
-            transform: scale(1) translateY(0);
+            transform: translate(-50%, -50%) scale(1);
         }
 
         .modal-title {


### PR DESCRIPTION
## Summary
- raise voucher modal overlay z-index to stay above layout components
- absolutely position modal at 50%/50% so it opens centered on the screen

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68ab7074242c8330a5ad0af854057afb

## Summary by Sourcery

Adjust the voucher modal overlay to ensure it appears centered on the screen and layered above other layout elements

Bug Fixes:
- Increase voucher modal overlay z-index to keep the dialog above layout components

Enhancements:
- Apply absolute positioning with 50% top/left and translate transforms to center the modal
- Update transform scaling for both hidden and visible states to maintain centering