### PR TITLE
feat: support category images with upload or link

### DIFF
--- a/public/admin/static/js/admin.js
+++ b/public/admin/static/js/admin.js
@@ -518,6 +518,57 @@ function initCategoryForm() {
   const form = document.getElementById("categoryForm");
   if (!form) return;
 
+  const imageFile = document.getElementById("imageFile");
+  const imagePreview = document.getElementById("imagePreview");
+  const imageUrlInput = document.getElementById("imageUrl");
+  const imageSourceSelect = document.getElementById("imageSourceSelect");
+  const imageLink = document.getElementById("imageLink");
+  const imageFileGroup = document.getElementById("imageFileGroup");
+  const imageLinkGroup = document.getElementById("imageLinkGroup");
+
+  if (imageFile && imagePreview) {
+    imageFile.addEventListener('change', () => {
+      const file = imageFile.files[0];
+      if (file) {
+        imagePreview.src = URL.createObjectURL(file);
+        imagePreview.style.display = 'block';
+      }
+    });
+  }
+
+  if (imageLink) {
+    imageLink.addEventListener('input', () => {
+      if (imageLink.value) {
+        imagePreview.src = imageLink.value;
+        imagePreview.style.display = 'block';
+      }
+    });
+  }
+
+  if (imageSourceSelect && imageFileGroup && imageLinkGroup) {
+    imageSourceSelect.addEventListener('change', () => {
+      const mode = imageSourceSelect.value;
+      if (mode === 'link') {
+        imageFileGroup.style.display = 'none';
+        imageLinkGroup.style.display = 'block';
+      } else {
+        imageFileGroup.style.display = 'block';
+        imageLinkGroup.style.display = 'none';
+      }
+    });
+  }
+
+  if (imageUrlInput && imageUrlInput.value) {
+    if (imageSourceSelect) imageSourceSelect.value = 'link';
+    if (imageFileGroup) imageFileGroup.style.display = 'none';
+    if (imageLinkGroup) imageLinkGroup.style.display = 'block';
+    if (imageLink) imageLink.value = imageUrlInput.value;
+    if (imagePreview) {
+      imagePreview.src = imageUrlInput.value;
+      imagePreview.style.display = 'block';
+    }
+  }
+
   form.addEventListener("submit", async e => {
     e.preventDefault();
 
@@ -527,6 +578,29 @@ function initCategoryForm() {
       description: fd.get("description") || ""
     };
     const id = fd.get("id");
+
+    let imageUrl = imageUrlInput ? imageUrlInput.value : '';
+    if (imageSourceSelect && imageSourceSelect.value === 'link') {
+      imageUrl = imageLink ? imageLink.value.trim() : '';
+    } else if (imageFile && imageFile.files[0]) {
+      const fdImg = new FormData();
+      fdImg.append('image', imageFile.files[0]);
+      try {
+        const upRes = await fetch(`${apiCategory}/upload`, {
+          method: 'POST',
+          body: fdImg
+        });
+        if (upRes.ok) {
+          const data = await upRes.json();
+          imageUrl = data.url;
+        }
+      } catch (err) {
+        console.error('Upload image error:', err);
+        showToast('Lỗi upload ảnh', 'error');
+      }
+    }
+    if (imageUrl) payload.image = imageUrl;
+
     const url = id ? `${apiCategory}/${id}` : apiCategory;
     const method = id ? "PUT" : "POST";
 

--- a/routes/admin.js
+++ b/routes/admin.js
@@ -72,8 +72,12 @@ router.get('/categories/create', (req, res) => {
 
 // Trang sửa danh mục
 router.get('/categories/edit/:id', async (req, res) => {
-  const category = await Category.findById(req.params.id).lean();
-  res.render('admin/category-form', { category });
+  const [category, image] = await Promise.all([
+    Category.findById(req.params.id).lean(),
+    Image.findOne({ category_id: req.params.id }).lean()
+  ]);
+  const categoryData = category ? { ...category, image: image ? image.url : '' } : {};
+  res.render('admin/category-form', { category: categoryData });
 });
 
 // bao cao

--- a/routes/categorys.js
+++ b/routes/categorys.js
@@ -1,12 +1,48 @@
 const express = require("express");
 const router = express.Router();
+const path = require("path");
+const fs = require("fs");
+const multer = require("multer");
 const Category = require("../models/Category");
+const Image = require("../models/Image");
+
+// Ensure uploads directory exists
+const uploadDir = path.join(__dirname, "../uploads/categories");
+fs.mkdirSync(uploadDir, { recursive: true });
+
+const storage = multer.diskStorage({
+  destination: (req, file, cb) => cb(null, uploadDir),
+  filename: (req, file, cb) => {
+    const uniq = Date.now() + "-" + Math.round(Math.random() * 1e9);
+    cb(null, uniq + path.extname(file.originalname));
+  }
+});
+const upload = multer({ storage });
+
+// Upload category image
+router.post("/upload", upload.single("image"), (req, res) => {
+  if (!req.file) {
+    return res.status(400).json({ error: "No file uploaded" });
+  }
+  const url = `/uploads/categories/${req.file.filename}`;
+  res.json({ url });
+});
 
 // GET all categories
 router.get("/", async (req, res) => {
   try {
-    const items = await Category.find();
-    res.json(items);
+    const categories = await Category.find().lean();
+    const ids = categories.map(c => c._id);
+    const images = await Image.find({ category_id: { $in: ids } }).lean();
+    const imageMap = {};
+    images.forEach(img => {
+      if (!imageMap[img.category_id]) imageMap[img.category_id] = img.url;
+    });
+    const result = categories.map(c => ({
+      ...c,
+      image: imageMap[c._id] || null
+    }));
+    res.json(result);
   } catch (err) {
     res.status(500).json({ error: err.message });
   }
@@ -19,7 +55,17 @@ router.get("/all", async (req, res) => {
 
     if (!page || !limit) {
       const items = await Category.find().sort({ createdAt: -1 }).lean();
-      return res.json({ categories: items, hasMore: false });
+      const ids = items.map(c => c._id);
+      const images = await Image.find({ category_id: { $in: ids } }).lean();
+      const imageMap = {};
+      images.forEach(img => {
+        if (!imageMap[img.category_id]) imageMap[img.category_id] = img.url;
+      });
+      const categoriesWithImage = items.map(c => ({
+        ...c,
+        image: imageMap[c._id] || null
+      }));
+      return res.json({ categories: categoriesWithImage, hasMore: false });
     }
 
     const safePage  = Math.max(1, page);
@@ -35,8 +81,19 @@ router.get("/all", async (req, res) => {
       Category.countDocuments()
     ]);
 
+    const ids = categories.map(c => c._id);
+    const images = await Image.find({ category_id: { $in: ids } }).lean();
+    const imageMap = {};
+    images.forEach(img => {
+      if (!imageMap[img.category_id]) imageMap[img.category_id] = img.url;
+    });
+    const categoriesWithImage = categories.map(c => ({
+      ...c,
+      image: imageMap[c._id] || null
+    }));
+
     return res.json({
-      categories,
+      categories: categoriesWithImage,
       hasMore: skip + categories.length < total
     });
 
@@ -49,9 +106,13 @@ router.get("/all", async (req, res) => {
 // GET category by id
 router.get("/:id", async (req, res) => {
   try {
-    const item = await Category.findById(req.params.id);
+    const item = await Category.findById(req.params.id).lean();
     if (!item) return res.status(404).json({ error: "Not found" });
-    res.json(item);
+    const img = await Image.findOne({ category_id: item._id }).lean();
+    res.json({
+      ...item,
+      image: img ? img.url : null
+    });
   } catch (err) {
     res.status(404).json({ error: "Not found" });
   }
@@ -60,9 +121,17 @@ router.get("/:id", async (req, res) => {
 // POST create category
 router.post("/", async (req, res) => {
   try {
-    const newItem = new Category(req.body);
+    const { image, ...data } = req.body;
+    const newItem = new Category(data);
     await newItem.save();
-    res.status(201).json(newItem);
+    if (image) {
+      await Image.findOneAndUpdate(
+        { category_id: newItem._id },
+        { url: image, category_id: newItem._id },
+        { upsert: true, new: true }
+      );
+    }
+    res.status(201).json({ ...newItem.toObject(), image: image || null });
   } catch (err) {
     res.status(400).json({ error: err.message });
   }
@@ -71,12 +140,20 @@ router.post("/", async (req, res) => {
 // PUT update category
 router.put("/:id", async (req, res) => {
   try {
+    const { image, ...data } = req.body;
     const updatedItem = await Category.findByIdAndUpdate(
       req.params.id,
-      req.body,
+      data,
       { new: true }
     );
-    res.json(updatedItem);
+    if (image) {
+      await Image.findOneAndUpdate(
+        { category_id: req.params.id },
+        { url: image, category_id: req.params.id },
+        { upsert: true, new: true }
+      );
+    }
+    res.json({ ...updatedItem.toObject(), image: image || null });
   } catch (err) {
     res.status(400).json({ error: err.message });
   }

--- a/views/admin/category-form.hbs
+++ b/views/admin/category-form.hbs
@@ -177,12 +177,21 @@
     </div>
     <div class="mb-3">
       <label class="form-label" for="image">Logo / Ảnh danh mục</label>
+      <select id="imageSourceSelect" class="form-select mb-2">
+        <option value="file">Tải lên file</option>
+        <option value="link">Dùng URL</option>
+      </select>
+      <div id="imageFileGroup">
+        <input type="file" id="imageFile" accept="image/*" class="form-control mb-2">
+      </div>
+      <div id="imageLinkGroup" style="display:none;">
+        <input type="text" id="imageLink" class="form-control mb-2" placeholder="Dán URL ảnh" value="{{category.image}}">
+      </div>
       {{#if category.image}}
         <img id="imagePreview" src="{{category.image}}" class="category-image-preview mb-2" alt="Ảnh danh mục">
       {{else}}
         <img id="imagePreview" src="/admin/static/images/no-image.png" class="category-image-preview mb-2" style="display:none" alt="Ảnh danh mục">
       {{/if}}
-      <input type="file" id="imageFile" accept="image/*" class="form-control mb-2">
       <input type="hidden" name="image" id="imageUrl" value="{{category.image}}">
     </div>
     <div class="modal-footer">
@@ -194,18 +203,4 @@
   </form>
 </div>
 
-<script>
-  // Hiển thị ảnh preview khi chọn file
-  document.getElementById('imageFile').addEventListener('change', function (e) {
-    const file = e.target.files[0];
-    const preview = document.getElementById('imagePreview');
-    if (file) {
-      const reader = new FileReader();
-      reader.onload = function (evt) {
-        preview.src = evt.target.result;
-        preview.style.display = 'block';
-      };
-      reader.readAsDataURL(file);
-    }
-  });
-</script>
+<script src="/admin/static/js/admin.js"></script>


### PR DESCRIPTION
## Summary
- add upload endpoint for category images and join Image collection when listing
- allow category form to use URL or file upload and submit image data
- load category image when editing

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68ad75169b6c8330a86377ce6f3dc47f

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Category form now supports images via file upload or URL, with a toggle to choose source and a live preview.
  - Existing images are preloaded in the form when editing; image value is saved with the category.
  - New image upload capability added; category APIs now accept and return an image field across create, update, fetch, and list endpoints.
  - Category lists and detail views now include associated image data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->