### PR TITLE
Soft delete for product assets and drop price field

### DIFF
--- a/controllers/productCtrl.js
+++ b/controllers/productCtrl.js
@@ -19,13 +19,14 @@ function normalizeVariants(raw) {
       if (Array.isArray(group.options)) {
         opts = group.options.map(opt => ({
           label: opt.label ?? opt,
-          priceDiff: opt.priceDiff ?? 0
+          priceDiff: opt.priceDiff ?? 0,
+          disabled: opt.disabled ?? false
         }));
       } else if (Array.isArray(group.values)) {
-        opts = group.values.map(v => ({ label: v, priceDiff: 0 }));
+        opts = group.values.map(v => ({ label: v, priceDiff: 0, disabled: false }));
       }
 
-      return { key, options: opts };
+      return { key, options: opts, disabled: group.disabled ?? false };
     })
     .filter(Boolean);
 }
@@ -37,7 +38,7 @@ exports.createProduct = async (req, res) => {
       name,
       category_id,
       brand_id,
-      price,
+      price = 0,
       description = '',
       stock = 0,
       specifications = [],
@@ -108,7 +109,6 @@ exports.updateProduct = async (req, res) => {
     if (req.body.name !== undefined) updates.name = req.body.name;
     if (req.body.category_id !== undefined) updates.category_id = req.body.category_id;
     if (req.body.brand_id !== undefined) updates.brand_id = req.body.brand_id;
-    if (req.body.price !== undefined) updates.price = req.body.price;
     if (req.body.description !== undefined) updates.description = req.body.description;
     if (req.body.stock !== undefined) updates.stock = req.body.stock;
 
@@ -145,7 +145,7 @@ exports.updateProduct = async (req, res) => {
 
     // Xử lý image nếu có
     if (req.body.image) {
-      await Image.deleteMany({ product_id: updated._id });
+      await Image.updateMany({ product_id: updated._id }, { disabled: true });
       await new Image({
         product_id: updated._id,
         url:        req.body.image
@@ -154,7 +154,7 @@ exports.updateProduct = async (req, res) => {
 
     // Nếu có mảng imageUrls, lưu tất cả ảnh
     if (Array.isArray(req.body.imageUrls)) {
-      await Image.deleteMany({ product_id: updated._id });
+      await Image.updateMany({ product_id: updated._id }, { disabled: true });
       for (const url of req.body.imageUrls) {
         await new Image({ product_id: updated._id, url }).save();
       }
@@ -176,20 +176,21 @@ exports.getProducts = async (req, res) => {
     const q     = (req.query.q || '').trim();
 
     const nameFilter = q ? { name: new RegExp(q, 'i') } : {};
+    const baseFilter = { ...nameFilter, disabled: { $ne: true } };
 
     const [products, total] = await Promise.all([
-      Product.find(nameFilter)
+      Product.find(baseFilter)
         .skip(skip)
         .limit(limit)
         .populate('category_id', 'name')
         .populate('brand_id', 'name')
         .lean(),
-      Product.countDocuments(nameFilter)
+      Product.countDocuments(baseFilter)
     ]);
 
     const productsWithImage = await Promise.all(
      products.map(async p => {
-    const img = await Image.findOne({ product_id: p._id }).lean();
+    const img = await Image.findOne({ product_id: p._id, disabled: { $ne: true } }).lean();
     return {
       ...p,
       image: img ? img.url : null,
@@ -223,13 +224,13 @@ exports.getProductById = async (req, res) => {
       .populate('category_id', 'name')
       .populate('brand_id', 'name')
       .lean();
-    
-    if (!item) {
+
+    if (!item || item.disabled) {
       return res.status(404).json({ error: 'Không tìm thấy sản phẩm' });
     }
 
     // images
-    const imgs = await Image.find({ product_id: item._id }).lean();
+    const imgs = await Image.find({ product_id: item._id, disabled: { $ne: true } }).lean();
     const urls = imgs.map(i => i.url);
     const primaryImage = urls[0] || null;
 
@@ -254,7 +255,13 @@ exports.getProductById = async (req, res) => {
       }));
     }
 
-    res.json({ ...item, image: primaryImage, images: urls, tskt });
+    const activeVariants = Array.isArray(item.variants)
+      ? item.variants
+          .filter(g => !g.disabled)
+          .map(g => ({ ...g, options: (g.options || []).filter(o => !o.disabled) }))
+      : [];
+
+    res.json({ ...item, variants: activeVariants, image: primaryImage, images: urls, tskt });
   } catch (err) {
     console.error('Error in getProductById:', err);
     res.status(500).json({ error: 'Đã xảy ra lỗi máy chủ, vui lòng thử lại sau.' });
@@ -269,12 +276,16 @@ exports.deleteProduct = async (req, res) => {
       return res.status(400).json({ error: 'ID sản phẩm không hợp lệ' });
     }
 
-    const deleted = await Product.findByIdAndDelete(req.params.id);
+    const deleted = await Product.findByIdAndUpdate(
+      req.params.id,
+      { disabled: true },
+      { new: true }
+    );
     if (!deleted) {
       return res.status(404).json({ error: 'Không tìm thấy sản phẩm' });
     }
 
-    await Image.deleteMany({ product_id: req.params.id });
+    await Image.updateMany({ product_id: req.params.id }, { disabled: true });
     res.json({ success: true });
   } catch (err) {
     console.error('Error in deleteProduct:', err);
@@ -291,7 +302,7 @@ exports.filterProducts = async (req, res) => {
       limit = 20
     } = req.query;
 
-    const filter = {};
+    const filter = { disabled: { $ne: true } };
     let sortOptions = {};
 
     // ------------------------
@@ -390,7 +401,7 @@ if (min !== null || max !== null) {
     // Fetch Images
     // ------------------------
     const productIds = products.map(p => p._id);
-    const images = await Image.find({ product_id: { $in: productIds } }).lean();
+    const images = await Image.find({ product_id: { $in: productIds }, disabled: { $ne: true } }).lean();
 
 const imageMap = {};
 images.forEach(img => {
@@ -457,7 +468,8 @@ exports.getBestSellers = async (req, res) => {
       { $unwind: '$productInfo' },
       {
         $match: {
-          'productInfo.category_id': new mongoose.Types.ObjectId(category)
+          'productInfo.category_id': new mongoose.Types.ObjectId(category),
+          'productInfo.disabled': { $ne: true }
         }
       },
       {
@@ -473,7 +485,7 @@ exports.getBestSellers = async (req, res) => {
 
     // Lấy ảnh đại diện cho từng sản phẩm
     const productIds = orders.map(o => o._id);
-    const images = await Image.find({ product_id: { $in: productIds } }).lean();
+    const images = await Image.find({ product_id: { $in: productIds }, disabled: { $ne: true } }).lean();
     const imageMap = {};
     images.forEach(img => {
       if (img.url && !imageMap[img.product_id]) {
@@ -513,8 +525,8 @@ exports.uploadProductsFromExcel = async (req, res) => {
 
     for (const row of rows) {
       try {
-        if (!row.name || !row.category_id || !row.price) {
-          errors.push(`Row skipped: Missing required fields (name, category_id, price)`);
+        if (!row.name || !row.category_id) {
+          errors.push(`Row skipped: Missing required fields (name, category_id)`);
           continue;
         }
 
@@ -554,7 +566,7 @@ exports.uploadProductsFromExcel = async (req, res) => {
           name:        row.name,
           category_id: row.category_id,
           brand_id:    row.brand_id || undefined,
-          price:       parseFloat(row.price),
+          price:       parseFloat(row.price) || 0,
           description: row.description || '',
           stock:       parseInt(row.stock) || 0,
           specifications: specs,
@@ -600,13 +612,13 @@ exports.uploadProductsFromExcel = async (req, res) => {
 // Export all products to Excel file
 exports.exportProductsToExcel = async (req, res) => {
   try {
-    const products = await Product.find()
+    const products = await Product.find({ disabled: { $ne: true } })
       .populate('category_id', 'name')
       .populate('brand_id', 'name')
       .lean();
 
     const ids = products.map(p => p._id);
-    const images = await Image.find({ product_id: { $in: ids } }).lean();
+    const images = await Image.find({ product_id: { $in: ids }, disabled: { $ne: true } }).lean();
     const imageMap = {};
     images.forEach(img => {
       if (!imageMap[img.product_id]) imageMap[img.product_id] = img.url;
@@ -649,7 +661,7 @@ exports.exportProductsToExcel = async (req, res) => {
 };
 exports.getAllProducts = async (req, res) => {
   try {
-    const products = await Product.find();
+    const products = await Product.find({ disabled: { $ne: true } });
     res.json(products);
   } catch (err) {
     res.status(500).json({ message: err.message });
@@ -660,7 +672,7 @@ exports.getAllProducts = async (req, res) => {
 exports.filterProductsByKeyword = async (req, res) => {
   try {
     const { keyword = '', page = 1, limit = 12 } = req.query;
-    const filter = {};
+    const filter = { disabled: { $ne: true } };
 
     if (keyword && keyword.trim()) {
       filter.$or = [
@@ -687,7 +699,7 @@ exports.filterProductsByKeyword = async (req, res) => {
     const validProducts = products.filter(p => p._id && mongoose.Types.ObjectId.isValid(p._id));
     const productIds = validProducts.map(p => p._id);
 
-    const images = await Image.find({ product_id: { $in: productIds } }).lean();
+    const images = await Image.find({ product_id: { $in: productIds }, disabled: { $ne: true } }).lean();
     const imageMap = {};
     images.forEach(img => {
       if (img.url && !imageMap[img.product_id]) {

--- a/models/Image.js
+++ b/models/Image.js
@@ -4,7 +4,8 @@ const imageSchema = new mongoose.Schema({
   url: { type: String, required: true },
   product_id: { type: mongoose.Schema.Types.ObjectId, ref: 'Product', default: null },
   category_id: { type: mongoose.Schema.Types.ObjectId, ref: 'Category', default: null },
-  description: String
+  description: String,
+  disabled: { type: Boolean, default: false }
 });
 
 module.exports = mongoose.model('Image', imageSchema);

--- a/models/Product.js
+++ b/models/Product.js
@@ -3,13 +3,15 @@ const mongoose = require('mongoose');
 // Schema cho từng option của một biến thể
 const variantOptionSchema = new mongoose.Schema({
   label:     { type: String, required: true, trim: true },   // tên biến thể, ví dụ "32GB"
-  priceDiff: { type: Number, required: true, default: 0 }    // chênh lệch so với price gốc
+  priceDiff: { type: Number, required: true, default: 0 },   // chênh lệch so với price gốc
+  disabled:  { type: Boolean, default: false }
 }, { _id: false });
 
 // Schema cho nhóm biến thể (nếu có nhiều nhóm, ví dụ "RAM", "Color")
 const variantGroupSchema = new mongoose.Schema({
-  key:     { type: String, required: true, trim: true },    // ví dụ "RAM"
-  options: { type: [variantOptionSchema], default: [] }     // mảng các option
+  key:      { type: String, required: true, trim: true },    // ví dụ "RAM"
+  options:  { type: [variantOptionSchema], default: [] },    // mảng các option
+  disabled: { type: Boolean, default: false }
 }, { _id: false });
 
 // Schema chính Product
@@ -17,12 +19,13 @@ const productSchema = new mongoose.Schema({
   name:           { type: String, required: true, trim: true },
   category_id:    { type: mongoose.Schema.Types.ObjectId, ref: 'Category', required: true },
   brand_id:       { type: mongoose.Schema.Types.ObjectId, ref: 'Brand' },
-  price:          { type: Number, required: true, min: 0 },  // giá gốc
+  price:          { type: Number, default: 0, min: 0 },  // giá gốc, không bắt buộc
   description:    { type: String, default: '' },
   stock:          { type: Number, default: 0, min: 0 },
   image:          { type: Object, default: '' },
   specifications: { type: [{ key: String, value: String }], default: [] },
-  variants:       { type: [variantGroupSchema], default: [] } // mảng nhóm biến thể
+  variants:       { type: [variantGroupSchema], default: [] }, // mảng nhóm biến thể
+  disabled:       { type: Boolean, default: false }
 }, { timestamps: true });
 
 module.exports = mongoose.model('Product', productSchema);

--- a/public/admin/static/js/admin.js
+++ b/public/admin/static/js/admin.js
@@ -146,7 +146,6 @@ async function initProductForm() {
   const imageLink = document.getElementById("imageLink");
   const imageFileGroup = document.getElementById("imageFileGroup");
   const imageLinkGroup = document.getElementById("imageLinkGroup");
-  const priceInput = form.querySelector('input[name="price"]');
   const stockInput = form.querySelector('input[name="stock"]');
 
   const getSpecInputs = () =>
@@ -161,7 +160,6 @@ async function initProductForm() {
     return;
   }
 
-  setupNumberInput(priceInput);
   setupNumberInput(stockInput);
 
   // Initialize CKEditor
@@ -357,7 +355,6 @@ async function initProductForm() {
 
         // Fill basic fields
         form.querySelector('input[name="name"]').value = prod.name || '';
-        if (priceInput) { priceInput.value = prod.price || ''; priceInput.dispatchEvent(new Event('input')); }
         if (stockInput) { stockInput.value = prod.stock || ''; stockInput.dispatchEvent(new Event('input')); }
         if (editor) editor.setData(prod.description || "");
         if (descInput) descInput.value = prod.description || '';
@@ -470,7 +467,6 @@ async function initProductForm() {
         name: fd.get("name"),
         category_id: fd.get("category_id"),
         brand_id: fd.get("brand_id"),
-        price: Number(String(fd.get("price")).replace(/[^0-9]/g, '')),
         stock: Number(String(fd.get("stock")).replace(/[^0-9]/g, '')),
         image: imageUrl,
         description: fd.get("description"),

--- a/public/js/product-form.js
+++ b/public/js/product-form.js
@@ -129,7 +129,6 @@ document.addEventListener('DOMContentLoaded', () => {
       const res = await fetch(`${apiProduct}/${id}`);
       const prod = await res.json();
       form.querySelector('input[name="name"]').value  = prod.name;
-      form.querySelector('input[name="price"]').value = prod.price;
       form.querySelector('input[name="stock"]').value = prod.stock;
       quill.root.innerHTML = prod.description || '';
       if (imagePreview) {
@@ -204,7 +203,6 @@ document.addEventListener('DOMContentLoaded', () => {
       name        : fd.get('name'),
       category_id : fd.get('category_id'),
       brand_id    : fd.get('brand_id'),
-      price       : parseFloat(fd.get('price')),
       stock       : parseInt(fd.get('stock')),
       image       : imageUrl,
       description : fd.get('description'),

--- a/routes/image.js
+++ b/routes/image.js
@@ -5,7 +5,9 @@ const Image = require('../models/Image');
 // GET all images
 router.get('/', async (req, res) => {
   try {
-    const items = await Image.find().populate('product_id').populate('category_id');
+    const items = await Image.find({ disabled: { $ne: true } })
+      .populate('product_id')
+      .populate('category_id');
     res.json(items);
   } catch (err) {
     res.status(500).json({ error: err.message });
@@ -15,8 +17,10 @@ router.get('/', async (req, res) => {
 // GET image by id
 router.get('/:id', async (req, res) => {
   try {
-    const item = await Image.findById(req.params.id).populate('product_id').populate('category_id');
-    if (!item) return res.status(404).json({ error: 'Not found' });
+    const item = await Image.findById(req.params.id)
+      .populate('product_id')
+      .populate('category_id');
+    if (!item || item.disabled) return res.status(404).json({ error: 'Not found' });
     res.json(item);
   } catch (err) {
     res.status(404).json({ error: 'Not found' });
@@ -47,8 +51,8 @@ router.put('/:id', async (req, res) => {
 // DELETE image
 router.delete('/:id', async (req, res) => {
   try {
-    await Image.findByIdAndDelete(req.params.id);
-    res.json({ message: 'Image deleted' });
+    await Image.findByIdAndUpdate(req.params.id, { disabled: true });
+    res.json({ message: 'Image disabled' });
   } catch (err) {
     res.status(400).json({ error: err.message });
   }

--- a/views/admin/form.hbs
+++ b/views/admin/form.hbs
@@ -59,11 +59,6 @@
     </div>
 
     <div class="form-group">
-      <label>Giá (VNĐ) *</label>
-      <input type="text" name="price" value="{{product.price}}" placeholder="Nhập giá sản phẩm" required class="number-input">
-    </div>
-
-    <div class="form-group">
       <label>Số lượng *</label>
       <input type="text" name="stock" value="{{product.stock}}" placeholder="Nhập số lượng" required class="number-input">
     </div>


### PR DESCRIPTION
## Summary
- add `disabled` flags to products, images, and variant schemas
- replace destructive deletes with soft disable and filter out disabled records
- remove product price input from admin forms and client scripts

## Testing
- `node --check controllers/productCtrl.js`
- `node --check models/Image.js`
- `node --check models/Product.js`
- `node --check public/admin/static/js/admin.js`
- `node --check public/js/product-form.js`
- `node --check routes/image.js`
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68ada41075d88330a62fabc5145ef4bb

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Soft-delete for products and images; disabled items are hidden across listings, detail pages, filters, best-sellers, and Excel import/export.
  - Variant groups/options support a disabled state; only active variants are displayed.

- Refactor
  - Product lists now include category and brand display names.
  - Price is optional (defaults to 0). Price fields were removed from the admin product form and are no longer editable.
  - Image “delete” is now a disable action; disabled images are excluded from lists and return not found when accessed.
  - Excel import tolerates missing prices; export/import skip disabled records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->