### PR TITLE
feat: add image support for categories

### DIFF
--- a/public/admin/static/js/admin.js
+++ b/public/admin/static/js/admin.js
@@ -420,6 +420,50 @@ async function initProductForm() {
 function initCategoryForm() {
   const form = document.getElementById("categoryForm");
   if (!form) return;
+  const linkInput = document.getElementById('imageLink');
+  const fileInput = document.getElementById('imageFile');
+  const preview = document.getElementById('imagePreview');
+  const imageIdInput = document.getElementById('imageId');
+  const linkRadio = document.getElementById('useLink');
+  const uploadRadio = document.getElementById('useUpload');
+
+  const toggleSource = () => {
+    if (linkRadio && uploadRadio) {
+      if (linkRadio.checked) {
+        if (linkInput) linkInput.style.display = 'block';
+        if (fileInput) fileInput.style.display = 'none';
+      } else {
+        if (linkInput) linkInput.style.display = 'none';
+        if (fileInput) fileInput.style.display = 'block';
+      }
+    }
+  };
+  if (linkRadio) linkRadio.addEventListener('change', toggleSource);
+  if (uploadRadio) uploadRadio.addEventListener('change', toggleSource);
+  toggleSource();
+
+  if (linkInput) {
+    linkInput.addEventListener('input', () => {
+      if (linkInput.value) {
+        preview.src = linkInput.value;
+        preview.style.display = 'block';
+      }
+    });
+  }
+
+  if (fileInput) {
+    fileInput.addEventListener('change', e => {
+      const file = e.target.files[0];
+      if (file) {
+        const reader = new FileReader();
+        reader.onload = evt => {
+          preview.src = evt.target.result;
+          preview.style.display = 'block';
+        };
+        reader.readAsDataURL(file);
+      }
+    });
+  }
 
   form.addEventListener("submit", async e => {
     e.preventDefault();
@@ -441,6 +485,39 @@ function initCategoryForm() {
       });
 
       if (!res.ok) throw new Error(`Save failed (${res.status})`);
+
+      const cat = await res.json();
+      const categoryId = cat._id || id;
+
+      let imageUrl = '';
+      if (linkRadio && linkRadio.checked && linkInput) {
+        imageUrl = linkInput.value.trim();
+      } else if (fileInput && fileInput.files[0]) {
+        const upFd = new FormData();
+        upFd.append('image', fileInput.files[0]);
+        const upRes = await fetch('/images/upload', { method: 'POST', body: upFd });
+        if (!upRes.ok) throw new Error('Upload image failed');
+        const upData = await upRes.json();
+        imageUrl = upData.url;
+      }
+
+      const imageId = imageIdInput ? imageIdInput.value : '';
+      if (imageUrl) {
+        const imgPayload = { url: imageUrl, category_id: categoryId };
+        if (imageId) {
+          await fetch(`/images/${imageId}`, {
+            method: 'PUT',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(imgPayload)
+          });
+        } else {
+          await fetch('/images', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(imgPayload)
+          });
+        }
+      }
 
       showToast('Lưu danh mục thành công', 'success');
       setTimeout(() => {

--- a/routes/admin.js
+++ b/routes/admin.js
@@ -79,15 +79,19 @@ router.get('/products/:id/edit', async (req, res) => {
 router.get('/categories', (req, res) => {
   res.render('admin/categories', { layout: 'admin/layout' });
 });
+
 // Trang tạo danh mục
 router.get('/categories/create', (req, res) => {
-  res.render('admin/category-form', { category: {} });
+  res.render('admin/category-form', { category: {}, image: null });
 });
 
 // Trang sửa danh mục
 router.get('/categories/edit/:id', async (req, res) => {
-  const category = await Category.findById(req.params.id).lean();
-  res.render('admin/category-form', { category });
+  const [category, image] = await Promise.all([
+    Category.findById(req.params.id).lean(),
+    Image.findOne({ category_id: req.params.id }).lean()
+  ]);
+  res.render('admin/category-form', { category, image });
 });
 
 // Quản lý thương hiệu
@@ -189,6 +193,25 @@ router.get('/api/products', async (req, res) => {
       image: imageMap[p._id] || null
     }));
     res.json(productsWithImage);
+  } catch (err) {
+    res.status(500).json({ message: err.message });
+  }
+});
+
+router.get('/api/categories', async (req, res) => {
+  try {
+    const categories = await Category.find().lean();
+    const ids = categories.map(c => c._id);
+    const images = await Image.find({ category_id: { $in: ids } }).lean();
+    const imageMap = {};
+    images.forEach(img => {
+      if (!imageMap[img.category_id]) imageMap[img.category_id] = img.url;
+    });
+    const categoriesWithImage = categories.map(c => ({
+      ...c,
+      image: imageMap[c._id] || null
+    }));
+    res.json(categoriesWithImage);
   } catch (err) {
     res.status(500).json({ message: err.message });
   }

--- a/views/admin/categories.hbs
+++ b/views/admin/categories.hbs
@@ -199,7 +199,7 @@
 
     async function fetchCategories() {
       setLoading(true);
-      const res = await fetch('/category');
+      const res = await fetch('/admin/api/categories');
       const data = await res.json();
       allCategories = data;
       setLoading(false);

--- a/views/admin/category-form.hbs
+++ b/views/admin/category-form.hbs
@@ -177,13 +177,22 @@
     </div>
     <div class="mb-3">
       <label class="form-label" for="image">Logo / Ảnh danh mục</label>
-      {{#if category.image}}
-        <img id="imagePreview" src="{{category.image}}" class="category-image-preview mb-2" alt="Ảnh danh mục">
+      {{#if image.url}}
+        <img id="imagePreview" src="{{image.url}}" class="category-image-preview mb-2" alt="Ảnh danh mục">
       {{else}}
         <img id="imagePreview" src="/admin/static/images/no-image.png" class="category-image-preview mb-2" style="display:none" alt="Ảnh danh mục">
       {{/if}}
-      <input type="file" id="imageFile" accept="image/*" class="form-control mb-2">
-      <input type="hidden" name="image" id="imageUrl" value="{{category.image}}">
+      <div class="form-check form-check-inline">
+        <input class="form-check-input" type="radio" name="imageSource" id="useLink" value="link" checked>
+        <label class="form-check-label" for="useLink">Link ảnh</label>
+      </div>
+      <div class="form-check form-check-inline">
+        <input class="form-check-input" type="radio" name="imageSource" id="useUpload" value="upload">
+        <label class="form-check-label" for="useUpload">Tải ảnh lên</label>
+      </div>
+      <input type="text" id="imageLink" class="form-control mb-2" placeholder="https://..." value="{{image.url}}">
+      <input type="file" id="imageFile" accept="image/*" class="form-control mb-2" style="display:none">
+      <input type="hidden" id="imageId" value="{{image._id}}">
     </div>
     <div class="modal-footer">
       <button type="submit" class="btn btn-primary">
@@ -195,18 +204,3 @@
 </div>
 
 <script src="/admin/static/js/admin.js"></script>
-<script>
-  // Hiển thị ảnh preview khi chọn file
-  document.getElementById('imageFile').addEventListener('change', function (e) {
-    const file = e.target.files[0];
-    const preview = document.getElementById('imagePreview');
-    if (file) {
-      const reader = new FileReader();
-      reader.onload = function (evt) {
-        preview.src = evt.target.result;
-        preview.style.display = 'block';
-      };
-      reader.readAsDataURL(file);
-    }
-  });
-</script>


### PR DESCRIPTION
## Summary
- load category images by joining image collection
- allow adding category image via link or upload
- expose `/admin/api/categories` to return categories with images

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68ada5d64f7c8330a9ad6d6416c2db6d