### PR TITLE
feat: soft delete items and remove product price input

### DIFF
--- a/controllers/productCtrl.js
+++ b/controllers/productCtrl.js
@@ -38,13 +38,13 @@ exports.createProduct = async (req, res) => {
       name,
       category_id,
       brand_id,
-      price,
+      price = 0,
       description = '',
       specifications = [],      // Mặc định là chuỗi JSON mảng
     } = req.body;
 
     // Validate required fields
-    if (!name || !category_id || !brand_id || price === undefined) {
+    if (!name || !category_id || !brand_id) {
       return res.status(400).json({ error: 'Thiếu trường bắt buộc' });
     }
 
@@ -142,7 +142,7 @@ exports.updateProduct = async (req, res) => {
 
     // Xử lý image nếu có
     if (req.body.image) {
-      await Image.deleteMany({ product_id: updated._id });
+      await Image.updateMany({ product_id: updated._id }, { isDisabled: true });
       await new Image({
         product_id: updated._id,
         url:        req.body.image
@@ -151,7 +151,7 @@ exports.updateProduct = async (req, res) => {
 
     // Nếu có mảng imageUrls, lưu tất cả ảnh
     if (Array.isArray(req.body.imageUrls)) {
-      await Image.deleteMany({ product_id: updated._id });
+      await Image.updateMany({ product_id: updated._id }, { isDisabled: true });
       for (const url of req.body.imageUrls) {
         await new Image({ product_id: updated._id, url }).save();
       }
@@ -172,7 +172,7 @@ exports.getProducts = async (req, res) => {
     const skip  = (page - 1) * limit;
     const q     = (req.query.q || '').trim();
 
-    const nameFilter = q ? { name: new RegExp(q, 'i') } : {};
+    const nameFilter = q ? { name: new RegExp(q, 'i'), isDisabled: false } : { isDisabled: false };
 
     const [products, total] = await Promise.all([
       Product.find(nameFilter)
@@ -186,8 +186,8 @@ exports.getProducts = async (req, res) => {
 
     const productsWithImage = await Promise.all(
       products.map(async p => {
-        const img = await Image.findOne({ product_id: p._id }).lean();
-        const variants = await VariantProduct.find({ product_id: p._id }).lean();
+        const img = await Image.findOne({ product_id: p._id, isDisabled: false }).lean();
+        const variants = await VariantProduct.find({ product_id: p._id, isDisabled: false }).lean();
         return {
           ...p,
           image: img ? img.url : null,
@@ -218,7 +218,7 @@ exports.getProductById = async (req, res) => {
       return res.status(400).json({ error: 'ID sản phẩm không hợp lệ' });
     }
 
-    const item = await Product.findById(req.params.id)
+    const item = await Product.findOne({ _id: req.params.id, isDisabled: false })
       .populate('category_id', 'name')
       .populate('brand_id', 'name')
       .lean();
@@ -228,10 +228,10 @@ exports.getProductById = async (req, res) => {
     }
 
     // Lấy biến thể từ bảng VariantProduct
-    const variants = await VariantProduct.find({ product_id: item._id }).lean();
+    const variants = await VariantProduct.find({ product_id: item._id, isDisabled: false }).lean();
 
     // images
-    const imgs = await Image.find({ product_id: item._id }).lean();
+    const imgs = await Image.find({ product_id: item._id, isDisabled: false }).lean();
     const urls = imgs.map(i => i.url);
     const primaryImage = urls[0] || null;
 
@@ -278,12 +278,17 @@ exports.deleteProduct = async (req, res) => {
       return res.status(400).json({ error: 'ID sản phẩm không hợp lệ' });
     }
 
-    const deleted = await Product.findByIdAndDelete(req.params.id);
-    if (!deleted) {
+    const product = await Product.findByIdAndUpdate(
+      req.params.id,
+      { isDisabled: true },
+      { new: true }
+    );
+    if (!product) {
       return res.status(404).json({ error: 'Không tìm thấy sản phẩm' });
     }
 
-    await Image.deleteMany({ product_id: req.params.id });
+    await Image.updateMany({ product_id: req.params.id }, { isDisabled: true });
+    await VariantProduct.updateMany({ product_id: req.params.id }, { isDisabled: true });
     res.json({ success: true });
   } catch (err) {
     console.error('Error in deleteProduct:', err);
@@ -300,7 +305,7 @@ exports.filterProducts = async (req, res) => {
       limit = 20
     } = req.query;
 
-    const filter = {};
+    const filter = { isDisabled: false };
     let sortOptions = {};
 
     // ------------------------
@@ -399,7 +404,7 @@ if (min !== null || max !== null) {
     // Fetch Images
     // ------------------------
     const productIds = products.map(p => p._id);
-    const images = await Image.find({ product_id: { $in: productIds } }).lean();
+    const images = await Image.find({ product_id: { $in: productIds }, isDisabled: false }).lean();
 
 const imageMap = {};
 images.forEach(img => {
@@ -483,7 +488,7 @@ exports.getBestSellers = async (req, res) => {
 
     // Lấy ảnh đại diện cho từng sản phẩm
     const productIds = orders.map(o => o._id);
-    const images = await Image.find({ product_id: { $in: productIds } }).lean();
+    const images = await Image.find({ product_id: { $in: productIds }, isDisabled: false }).lean();
     const imageMap = {};
     images.forEach(img => {
       if (img.url && !imageMap[img.product_id]) {
@@ -616,7 +621,7 @@ exports.exportProductsToExcel = async (req, res) => {
       .lean();
 
     const ids = products.map(p => p._id);
-    const images = await Image.find({ product_id: { $in: ids } }).lean();
+    const images = await Image.find({ product_id: { $in: ids }, isDisabled: false }).lean();
     const imageMap = {};
     images.forEach(img => {
       if (!imageMap[img.product_id]) imageMap[img.product_id] = img.url;
@@ -697,7 +702,7 @@ exports.filterProductsByKeyword = async (req, res) => {
     const validProducts = products.filter(p => p._id && mongoose.Types.ObjectId.isValid(p._id));
     const productIds = validProducts.map(p => p._id);
 
-    const images = await Image.find({ product_id: { $in: productIds } }).lean();
+    const images = await Image.find({ product_id: { $in: productIds }, isDisabled: false }).lean();
     const imageMap = {};
     images.forEach(img => {
       if (img.url && !imageMap[img.product_id]) {
@@ -730,12 +735,12 @@ exports.getProductsByCategory = async (req, res) => {
       return res.status(400).json({ error: 'ID danh mục không hợp lệ' });
     }
 
-    const products = await Product.find({ category_id: categoryId })
+    const products = await Product.find({ category_id: categoryId, isDisabled: false })
       .populate('category_id', 'name')
       .lean();
 
     const productIds = products.map(p => p._id);
-    const images = await Image.find({ product_id: { $in: productIds } }).lean();
+    const images = await Image.find({ product_id: { $in: productIds }, isDisabled: false }).lean();
     const imageMap = {};
     images.forEach(img => {
       if (img.url && !imageMap[img.product_id]) {
@@ -744,7 +749,7 @@ exports.getProductsByCategory = async (req, res) => {
     });
 
     const productsWithImages = await Promise.all(products.map(async p => {
-      const variants = await VariantProduct.find({ product_id: p._id }).lean();
+      const variants = await VariantProduct.find({ product_id: p._id, isDisabled: false }).lean();
       return {
         ...p,
         image: imageMap[p._id.toString()] || null,

--- a/models/Image.js
+++ b/models/Image.js
@@ -4,7 +4,8 @@ const imageSchema = new mongoose.Schema({
   url: { type: String, required: true },
   product_id: { type: mongoose.Schema.Types.ObjectId, ref: 'Product', default: null },
   category_id: { type: mongoose.Schema.Types.ObjectId, ref: 'Category', default: null },
-  description: String
+  description: String,
+  isDisabled: { type: Boolean, default: false }
 });
 
 module.exports = mongoose.model('Image', imageSchema);

--- a/models/Product.js
+++ b/models/Product.js
@@ -4,12 +4,13 @@ const productSchema = new mongoose.Schema({
   name:           { type: String, required: true, trim: true },
   category_id:    { type: mongoose.Schema.Types.ObjectId, ref: 'Category', required: true },
   brand_id:       { type: mongoose.Schema.Types.ObjectId, ref: 'Brand' },
-  price:          { type: Number, required: true, min: 0 },
+  price:          { type: Number, default: 0, min: 0 },
   description:    { type: String, default: '' },
   image:          { type: Object, default: '' },
   specifications: { type: [{ key: String, value: String }], default: [] },
   rating:         { type: Number, default: 0 },        // Thêm dòng này
-  reviewCount:    { type: Number, default: 0 }         // Thêm dòng này
+  reviewCount:    { type: Number, default: 0 },        // Thêm dòng này
+  isDisabled:     { type: Boolean, default: false }
 }, { timestamps: true });
 
 module.exports = mongoose.model('Product', productSchema);

--- a/models/Variantproduct.js
+++ b/models/Variantproduct.js
@@ -3,8 +3,9 @@ const VariantproductSchema = new mongoose.Schema({
   product_id: { type: mongoose.Schema.Types.ObjectId, ref: 'Product' },
   name:           { type: String, required: true, trim: true },
   price:          { type: Number, required: true, min: 0 },
-  stock:          { type: Number, default: 0, min: 0 }
-  
+  stock:          { type: Number, default: 0, min: 0 },
+  isDisabled:     { type: Boolean, default: false }
+
 }, { timestamps: true });
 
 module.exports = mongoose.model('VariantProduct', VariantproductSchema);

--- a/public/js/product-form.js
+++ b/public/js/product-form.js
@@ -129,8 +129,6 @@ document.addEventListener('DOMContentLoaded', () => {
       const res = await fetch(`${apiProduct}/${id}`);
       const prod = await res.json();
       form.querySelector('input[name="name"]').value  = prod.name;
-      form.querySelector('input[name="price"]').value = prod.price;
-      form.querySelector('input[name="stock"]').value = prod.stock;
       quill.root.innerHTML = prod.description || '';
       if (imagePreview) {
         imagePreview.src = prod.image || '';
@@ -204,8 +202,6 @@ document.addEventListener('DOMContentLoaded', () => {
       name        : fd.get('name'),
       category_id : fd.get('category_id'),
       brand_id    : fd.get('brand_id'),
-      price       : parseFloat(fd.get('price')),
-      stock       : parseInt(fd.get('stock')),
       image       : imageUrl,
       description : fd.get('description'),
       tskt: Array.from(specContainer.querySelectorAll('.spec-item input')).map(inp => ({ key: inp.previousElementSibling.textContent, value: inp.value })),

--- a/routes/image.js
+++ b/routes/image.js
@@ -21,7 +21,7 @@ const upload = multer({ storage });
 // GET all images (optionally filtered by product or category)
 router.get('/', async (req, res) => {
   try {
-    const filter = {};
+    const filter = { isDisabled: false };
     if (req.query.product_id) filter.product_id = req.query.product_id;
     if (req.query.category_id) filter.category_id = req.query.category_id;
     const items = await Image.find(filter).populate('product_id').populate('category_id');
@@ -43,7 +43,7 @@ router.post('/upload', upload.single('image'), (req, res) => {
 // GET image by id
 router.get('/:id', async (req, res) => {
   try {
-    const item = await Image.findById(req.params.id).populate('product_id').populate('category_id');
+    const item = await Image.findOne({ _id: req.params.id, isDisabled: false }).populate('product_id').populate('category_id');
     if (!item) return res.status(404).json({ error: 'Not found' });
     res.json(item);
   } catch (err) {
@@ -75,8 +75,8 @@ router.put('/:id', async (req, res) => {
 // DELETE image
 router.delete('/:id', async (req, res) => {
   try {
-    await Image.findByIdAndDelete(req.params.id);
-    res.json({ message: 'Image deleted' });
+    await Image.findByIdAndUpdate(req.params.id, { isDisabled: true });
+    res.json({ message: 'Image disabled' });
   } catch (err) {
     res.status(400).json({ error: err.message });
   }

--- a/routes/products.js
+++ b/routes/products.js
@@ -99,7 +99,7 @@ router.get('/:id', async (req, res) => {
       return res.status(400).json({ error: 'ID sản phẩm không hợp lệ' });
     }
 
-    const product = await Product.findById(req.params.id)
+    const product = await Product.findOne({ _id: req.params.id, isDisabled: false })
       .populate('category_id')
       .populate('brand_id')
       .lean();
@@ -110,7 +110,7 @@ router.get('/:id', async (req, res) => {
 
     // ===== GỘP: Lấy hình ảnh từ collection Image =====
     // Nếu có field đánh dấu thứ tự/primary, bạn có thể thêm sort({ isPrimary: -1, createdAt: 1 })
-    const imgs = await Image.find({ product_id: product._id }).lean();
+    const imgs = await Image.find({ product_id: product._id, isDisabled: false }).lean();
     const urls = (imgs || []).map(i => i.url).filter(Boolean);
     const primaryImage = urls[0] || null;
 
@@ -119,7 +119,7 @@ router.get('/:id', async (req, res) => {
     product.image = primaryImage || product.image || null;
 
     // ===== Lấy variant và format về group cho UI =====
-    const variants = await VariantProduct.find({ product_id: product._id }).lean();
+    const variants = await VariantProduct.find({ product_id: product._id, isDisabled: false }).lean();
 
     product.variants = [
       {

--- a/routes/variant.js
+++ b/routes/variant.js
@@ -29,7 +29,7 @@ router.post('/create', async (req, res) => {
 // Lấy tất cả biến thể
 router.get('/', async (req, res) => {
   try {
-    const variants = await VariantProduct.find()
+    const variants = await VariantProduct.find({ isDisabled: false })
       .populate('product_id', 'name')
       .lean();
     res.json(variants);
@@ -45,7 +45,7 @@ router.get('/by-product/:productId', async (req, res) => {
     if (!mongoose.Types.ObjectId.isValid(productId)) {
       return res.status(400).json({ error: 'productId không hợp lệ' });
     }
-    const variants = await VariantProduct.find({ product_id: productId })
+    const variants = await VariantProduct.find({ product_id: productId, isDisabled: false })
       .populate('product_id', 'name')
       .lean();
     res.json(variants);
@@ -57,7 +57,7 @@ router.get('/by-product/:productId', async (req, res) => {
 // Lấy biến thể theo id
 router.get('/:id', async (req, res) => {
   try {
-    const variant = await VariantProduct.findById(req.params.id);
+    const variant = await VariantProduct.findOne({ _id: req.params.id, isDisabled: false });
     if (!variant) return res.status(404).json({ error: 'Không tìm thấy biến thể' });
     res.json(variant);
   } catch (err) {
@@ -84,9 +84,9 @@ router.put('/:id', async (req, res) => {
 // Xóa biến thể
 router.delete('/:id', async (req, res) => {
   try {
-    const variant = await VariantProduct.findByIdAndDelete(req.params.id);
+    const variant = await VariantProduct.findByIdAndUpdate(req.params.id, { isDisabled: true });
     if (!variant) return res.status(404).json({ error: 'Không tìm thấy biến thể' });
-    res.json({ message: 'Đã xóa biến thể' });
+    res.json({ message: 'Đã vô hiệu hóa biến thể' });
   } catch (err) {
     res.status(500).json({ error: err.message });
   }

--- a/views/admin/form.hbs
+++ b/views/admin/form.hbs
@@ -44,10 +44,6 @@
         <input type="text" name="name" value="{{product.name}}" placeholder="Nhập tên sản phẩm" required>
       </div>
 
-      <div class="form-group">
-        <label>Giá (VNĐ) *</label>
-        <input type="text" name="price" value="{{product.price}}" placeholder="Nhập giá sản phẩm" required class="number-input">
-      </div>
     </div>
 
     <div class="form-section">


### PR DESCRIPTION
## Summary
- use `isDisabled` flag on products, images, and variants instead of deleting
- skip showing or fetching disabled records
- drop price field from product creation/edit forms

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68adaafb89d08330a063b5940d4cc6a1