### PR TITLE
feat: add soft delete infrastructure and admin trash views

### DIFF
--- a/controllers/productCtrl.js
+++ b/controllers/productCtrl.js
@@ -171,17 +171,28 @@ exports.getProducts = async (req, res) => {
     const limit = Math.max(1, +req.query.limit || 20);
     const skip  = (page - 1) * limit;
     const q     = (req.query.q || '').trim();
+    const view  = req.query.view || 'active';
 
     const nameFilter = q ? { name: new RegExp(q, 'i') } : {};
 
+    let findQuery = Product.find(nameFilter);
+    let countQuery = Product.countDocuments(nameFilter);
+    if (view === 'trash') {
+      findQuery = findQuery.onlyDeleted();
+      countQuery = countQuery.onlyDeleted();
+    } else if (view === 'all') {
+      findQuery = findQuery.withDeleted();
+      countQuery = countQuery.withDeleted();
+    }
+
     const [products, total] = await Promise.all([
-      Product.find(nameFilter)
+      findQuery
         .skip(skip)
         .limit(limit)
         .populate('category_id', 'name')
         .populate('brand_id', 'name')
         .lean(),
-      Product.countDocuments(nameFilter)
+      countQuery
     ]);
 
     const productsWithImage = await Promise.all(
@@ -278,15 +289,47 @@ exports.deleteProduct = async (req, res) => {
       return res.status(400).json({ error: 'ID sản phẩm không hợp lệ' });
     }
 
-    const deleted = await Product.findByIdAndDelete(req.params.id);
-    if (!deleted) {
+    const product = await Product.findById(req.params.id).withDeleted();
+    if (!product) {
+      return res.status(404).json({ error: 'Không tìm thấy sản phẩm' });
+    }
+
+    await product.softDelete(req.user?._id);
+    res.json({ success: true });
+  } catch (err) {
+    console.error('Error in deleteProduct:', err);
+    res.status(400).json({ error: err.message });
+  }
+};
+
+// Restore product
+exports.restoreProduct = async (req, res) => {
+  try {
+    const product = await Product.findById(req.params.id).withDeleted();
+    if (!product) {
+      return res.status(404).json({ error: 'Không tìm thấy sản phẩm' });
+    }
+    await product.restore();
+    res.json({ success: true });
+  } catch (err) {
+    console.error('Error in restoreProduct:', err);
+    res.status(400).json({ error: err.message });
+  }
+};
+
+// Purge product - hard delete
+exports.purgeProduct = async (req, res) => {
+  try {
+    const product = await Product.findById(req.params.id).withDeleted();
+    if (!product) {
       return res.status(404).json({ error: 'Không tìm thấy sản phẩm' });
     }
 
     await Image.deleteMany({ product_id: req.params.id });
+    await product.deleteOne();
     res.json({ success: true });
   } catch (err) {
-    console.error('Error in deleteProduct:', err);
+    console.error('Error in purgeProduct:', err);
     res.status(400).json({ error: err.message });
   }
 };

--- a/models/Brand.js
+++ b/models/Brand.js
@@ -1,8 +1,12 @@
 const mongoose = require('mongoose');
+const softDelete = require('./plugins/softDelete');
 
 const brandSchema = new mongoose.Schema({
   name: { type: String, required: true },
   logo: String
+
 });
+
+brandSchema.plugin(softDelete);
 
 module.exports = mongoose.model('Brand', brandSchema);

--- a/models/Category.js
+++ b/models/Category.js
@@ -1,8 +1,12 @@
 const mongoose = require('mongoose');
+const softDelete = require('./plugins/softDelete');
 
 const categorySchema = new mongoose.Schema({
   name: { type: String, required: true },
   description: String
+
 });
+
+categorySchema.plugin(softDelete);
 
 module.exports = mongoose.model('Category', categorySchema);

--- a/models/Product.js
+++ b/models/Product.js
@@ -1,4 +1,5 @@
 const mongoose = require('mongoose');
+const softDelete = require('./plugins/softDelete');
 
 const productSchema = new mongoose.Schema({
   name:           { type: String, required: true, trim: true },
@@ -10,6 +11,9 @@ const productSchema = new mongoose.Schema({
   specifications: { type: [{ key: String, value: String }], default: [] },
   rating:         { type: Number, default: 0 },        // Thêm dòng này
   reviewCount:    { type: Number, default: 0 }         // Thêm dòng này
+
 }, { timestamps: true });
+
+productSchema.plugin(softDelete);
 
 module.exports = mongoose.model('Product', productSchema);

--- a/models/plugins/softDelete.js
+++ b/models/plugins/softDelete.js
@@ -1,0 +1,63 @@
+const { Schema } = require('mongoose');
+
+module.exports = function softDelete(schema) {
+  schema.add({
+    isDeleted: { type: Boolean, default: false, index: true },
+    deletedAt: { type: Date, default: null },
+    deletedBy: { type: Schema.Types.ObjectId, ref: 'User', default: null }
+  });
+
+  // query helpers
+  schema.query.notDeleted = function () {
+    this.setOptions({ withDeleted: false });
+    return this.where({ isDeleted: false });
+  };
+  schema.query.onlyDeleted = function () {
+    this.setOptions({ withDeleted: true });
+    return this.where({ isDeleted: true });
+  };
+  schema.query.withDeleted = function () {
+    this.setOptions({ withDeleted: true });
+    return this;
+  };
+
+  function addFilter(next) {
+    if (this.options.withDeleted) return next();
+    const filter = this.getFilter();
+    if (filter.isDeleted === undefined) {
+      this.where({ isDeleted: false });
+    }
+    next();
+  }
+
+  schema.pre('find', addFilter);
+  schema.pre('findOne', addFilter);
+  schema.pre('count', addFilter);
+  schema.pre('countDocuments', addFilter);
+  schema.pre('findOneAndUpdate', addFilter);
+  schema.pre('updateMany', addFilter);
+
+  schema.pre('aggregate', function (next) {
+    if (this.options && this.options.withDeleted) return next();
+    const first = this.pipeline()[0];
+    if (!first || !first.$match || first.$match.isDeleted === undefined) {
+      this.pipeline().unshift({ $match: { isDeleted: false } });
+    }
+    next();
+  });
+
+  // instance methods
+  schema.methods.softDelete = function (userId) {
+    this.isDeleted = true;
+    this.deletedAt = new Date();
+    this.deletedBy = userId || null;
+    return this.save();
+  };
+
+  schema.methods.restore = function () {
+    this.isDeleted = false;
+    this.deletedAt = null;
+    this.deletedBy = null;
+    return this.save();
+  };
+};

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "scripts": {
     "start": "node ./bin/www",
-    "dev": "nodemon ./bin/www"
+    "dev": "nodemon ./bin/www",
+    "migrate:soft": "node scripts/migrate-soft-delete.js"
   },
   "dependencies": {
     "@google/generative-ai": "^0.24.1",

--- a/public/admin/static/js/admin.js
+++ b/public/admin/static/js/admin.js
@@ -38,6 +38,7 @@ let hasMore = true;
 const limit = 20;
 let observer; // IntersectionObserver reference
 let productQuery = '';
+let productView = 'active';
 
 /**
  * Fetch products from API with pagination
@@ -46,7 +47,7 @@ let productQuery = '';
 async function fetchProducts(page = 1, q = productQuery) {
   if (!hasMore && page !== 1) return;
   try {
-    const url = `${apiProduct}?page=${page}&limit=${limit}&q=${encodeURIComponent(q)}`;
+    const url = `${apiProduct}?page=${page}&limit=${limit}&q=${encodeURIComponent(q)}&view=${productView}`;
     const res = await fetch(url);
     if (!res.ok) throw new Error(`HTTP error! status: ${res.status}`);
 
@@ -88,14 +89,12 @@ function renderProducts(products, append = false) {
   products.forEach(p => {
     const tr = document.createElement("tr");
     const price = new Intl.NumberFormat("vi-VN", { style: "currency", currency: "VND" }).format(p.price || 0);
-    const stock = p.stock ?? 0;
     const variantCount = Array.isArray(p.variants) ? p.variants.length : 0;
-    tr.innerHTML = `
-      <td><img src="${p.image}" class="product-img" alt="${p.name}"></td>
-      <td>${p.name}</td>
-      <td>${price}</td>
-      <td>${variantCount}</td>
-       <td class="actions text-center">
+    if (p.isDeleted) {
+      tr.style.opacity = '0.5';
+      tr.style.textDecoration = 'line-through';
+    }
+    let actions = `
            <a href="/admin/products/${p._id}/edit" class="inline-block mx-1 p-2 hover:bg-gray-100 rounded">
              <i class="bx bx-edit text-xl"></i>
            </a>
@@ -105,10 +104,27 @@ function renderProducts(products, append = false) {
             <a href="/admin/variants?productId=${encodeURIComponent(p._id)}" class="inline-block mx-1 p-2 hover:bg-gray-100 rounded">
               <i class="bx bx-layer text-xl"></i>
             </a>
+    `;
+    if (p.isDeleted) {
+      actions += `
+           <a href="#" onclick="restoreProduct('${p._id}')" class="inline-block mx-1 p-2 hover:bg-gray-100 rounded">
+             <i class="bx bx-undo text-xl"></i>
+           </a>
+           <a href="#" onclick="purgeProduct('${p._id}')" class="inline-block mx-1 p-2 hover:bg-gray-100 rounded">
+             <i class="bx bx-trash text-xl"></i>
+           </a>`;
+    } else {
+      actions += `
            <a href="#" onclick="deleteProduct('${p._id}')" class="inline-block mx-1 p-2 hover:bg-gray-100 rounded">
              <i class="bx bx-trash text-xl"></i>
-           </a>
-         </td>`;
+           </a>`;
+    }
+    tr.innerHTML = `
+      <td><img src="${p.image}" class="product-img" alt="${p.name}"></td>
+      <td>${p.name}</td>
+      <td>${price}</td>
+      <td>${variantCount}</td>
+      <td class="actions text-center">${actions}</td>`;
     tbody.appendChild(tr);
   });
 }
@@ -131,6 +147,35 @@ async function deleteProduct(id) {
   } catch (err) {
     console.error("Lỗi xóa sản phẩm:", err);
     showToast('Lỗi xóa sản phẩm', 'error');
+  }
+}
+
+async function restoreProduct(id) {
+  try {
+    const res = await fetch(`${apiProduct}/${id}/restore`, { method: 'POST' });
+    if (!res.ok) throw new Error('Restore failed');
+    currentPage = 1;
+    hasMore = true;
+    fetchProducts(1, productQuery);
+    showToast('Khôi phục thành công', 'success');
+  } catch (err) {
+    console.error('Lỗi khôi phục sản phẩm:', err);
+    showToast('Lỗi khôi phục sản phẩm', 'error');
+  }
+}
+
+async function purgeProduct(id) {
+  if (!confirm('Xóa vĩnh viễn sản phẩm này?')) return;
+  try {
+    const res = await fetch(`${apiProduct}/${id}/purge`, { method: 'DELETE' });
+    if (!res.ok) throw new Error('Purge failed');
+    currentPage = 1;
+    hasMore = true;
+    fetchProducts(1, productQuery);
+    showToast('Đã xóa vĩnh viễn', 'success');
+  } catch (err) {
+    console.error('Lỗi xóa vĩnh viễn sản phẩm:', err);
+    showToast('Lỗi xóa vĩnh viễn', 'error');
   }
 }
 
@@ -555,6 +600,7 @@ document.addEventListener("DOMContentLoaded", () => {
 
   // Products
   if (document.getElementById("productTable")) {
+    productView = new URLSearchParams(window.location.search).get('view') || 'active';
     initProductScroll();
     fetchProducts(1);
     initExcelUpload();

--- a/public/admin/static/js/categories.js
+++ b/public/admin/static/js/categories.js
@@ -8,6 +8,7 @@ let catHasMore     = true;
 const catLimit     = 20;
 let catObserver;
 let allCategories = [];
+let categoryView = 'active';
 
 /**
  * Fetch categories (pagination)
@@ -15,7 +16,7 @@ let allCategories = [];
 async function fetchCategories(page = 1) {
   if (!catHasMore && page !== 1) return;
   try {
-    const res = await fetch(`${apiCategory}/all?page=${page}&limit=${catLimit}`);
+    const res = await fetch(`${apiCategory}/all?page=${page}&limit=${catLimit}&view=${categoryView}`);
     if (!res.ok) throw new Error(`HTTP lỗi! status: ${res.status}`);
     const data = await res.json();
 
@@ -55,20 +56,35 @@ function renderCategories(categories, append = false) {
 
   categories.forEach((c, idx) => {
     const tr = document.createElement("tr");
+    if (c.isDeleted) {
+      tr.style.opacity = '0.5';
+      tr.style.textDecoration = 'line-through';
+    }
+    let actions = `
+        <a href="/admin/categories/${c._id}/edit" class="inline-block mx-1 p-2 hover:bg-gray-100 rounded">
+          <i class="bx bx-edit text-xl"></i>
+        </a>`;
+    if (c.isDeleted) {
+      actions += `
+        <a href="#" onclick="restoreCategory('${c._id}')" class="inline-block mx-1 p-2 hover:bg-gray-100 rounded">
+          <i class="bx bx-undo text-xl"></i>
+        </a>
+        <a href="#" onclick="purgeCategory('${c._id}')" class="inline-block mx-1 p-2 hover:bg-gray-100 rounded">
+          <i class="bx bx-trash text-xl"></i>
+        </a>`;
+    } else {
+      actions += `
+        <a href="#" onclick="deleteCategory('${c._id}')" class="inline-block mx-1 p-2 hover:bg-gray-100 rounded">
+          <i class="bx bx-trash text-xl"></i>
+        </a>`;
+    }
     tr.innerHTML = `
       <td class="px-6 py-4">
         ${(catCurrentPage - 1) * catLimit + idx + 1}
       </td>
       <td class="px-6 py-4">${c.name}</td>
       <td class="px-6 py-4">${c.description || ""}</td>
-      <td class="px-6 py-4 text-center">
-        <a href="/admin/categories/${c._id}/edit" class="inline-block mx-1 p-2 hover:bg-gray-100 rounded">
-          <i class="bx bx-edit text-xl"></i>
-        </a>
-        <a href="#" onclick="deleteCategory('${c._id}')" class="inline-block mx-1 p-2 hover:bg-gray-100 rounded">
-          <i class="bx bx-trash text-xl"></i>
-        </a>
-      </td>
+      <td class="px-6 py-4 text-center">${actions}</td>
     `;
     tbody.appendChild(tr);
   });
@@ -88,6 +104,31 @@ async function deleteCategory(id) {
     fetchCategories(1);
   } catch (err) {
     console.error("Lỗi xóa danh mục:", err);
+  }
+}
+
+async function restoreCategory(id) {
+  try {
+    const res = await fetch(`${apiCategory}/${id}/restore`, { method: 'POST' });
+    if (!res.ok) throw new Error('Restore failed');
+    catCurrentPage = 1;
+    catHasMore = true;
+    fetchCategories(1);
+  } catch (err) {
+    console.error('Lỗi khôi phục danh mục:', err);
+  }
+}
+
+async function purgeCategory(id) {
+  if (!confirm('Xóa vĩnh viễn danh mục này?')) return;
+  try {
+    const res = await fetch(`${apiCategory}/${id}/purge`, { method: 'DELETE' });
+    if (!res.ok) throw new Error('Purge failed');
+    catCurrentPage = 1;
+    catHasMore = true;
+    fetchCategories(1);
+  } catch (err) {
+    console.error('Lỗi xóa vĩnh viễn danh mục:', err);
   }
 }
 
@@ -117,6 +158,7 @@ function initCategoryScroll() {
 
 // Khởi động khi DOM sẵn sàng
 document.addEventListener("DOMContentLoaded", () => {
+  categoryView = new URLSearchParams(window.location.search).get('view') || 'active';
   initCategoryScroll();
   fetchCategories(1);
 });

--- a/routes/admin.js
+++ b/routes/admin.js
@@ -39,11 +39,8 @@ router.get('/users/:id/edit', async (req, res) => {
 
 // Quản lý Sản phẩm
 router.get('/products', async (req, res) => {
-  const products = await Product.find()
-    .populate('category_id', 'name')
-    .populate('brand_id', 'name')
-    .lean();
-  res.render('admin/products-static', { layout: 'admin/layout', products });
+  const view = req.query.view || 'active';
+  res.render('admin/products-static', { layout: 'admin/layout', view });
 });
 router.get('/products/create', async (req, res) => {
   const [categories, brands] = await Promise.all([

--- a/routes/categorys.js
+++ b/routes/categorys.js
@@ -5,7 +5,11 @@ const Category = require("../models/Category");
 // GET all categories
 router.get("/", async (req, res) => {
   try {
-    const items = await Category.find();
+    const view = req.query.view || 'active';
+    let query = Category.find();
+    if (view === 'trash') query = query.onlyDeleted();
+    else if (view === 'all') query = query.withDeleted();
+    const items = await query.lean();
     res.json(items);
   } catch (err) {
     res.status(500).json({ error: err.message });
@@ -26,13 +30,20 @@ router.get("/all", async (req, res) => {
     const safeLimit = Math.max(1, limit);
     const skip      = (safePage - 1) * safeLimit;
 
+    const view = req.query.view || 'active';
+    let findQuery = Category.find().sort({ createdAt: -1 }).skip(skip).limit(safeLimit);
+    let countQuery = Category.countDocuments();
+    if (view === 'trash') {
+      findQuery = findQuery.onlyDeleted();
+      countQuery = countQuery.onlyDeleted();
+    } else if (view === 'all') {
+      findQuery = findQuery.withDeleted();
+      countQuery = countQuery.withDeleted();
+    }
+
     const [categories, total] = await Promise.all([
-      Category.find()
-              .sort({ createdAt: -1 })
-              .skip(skip)
-              .limit(safeLimit)
-              .lean(),
-      Category.countDocuments()
+      findQuery.lean(),
+      countQuery
     ]);
 
     return res.json({
@@ -85,8 +96,30 @@ router.put("/:id", async (req, res) => {
 // DELETE category
 router.delete("/:id", async (req, res) => {
   try {
-    await Category.findByIdAndDelete(req.params.id);
+    const doc = await Category.findById(req.params.id).withDeleted();
+    if (!doc) return res.status(404).json({ error: "Not found" });
+    await doc.softDelete(req.user?._id);
     res.json({ message: "Category deleted" });
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+});
+
+router.post('/:id/restore', async (req, res) => {
+  try {
+    const doc = await Category.findById(req.params.id).withDeleted();
+    if (!doc) return res.status(404).json({ error: 'Not found' });
+    await doc.restore();
+    res.json({ message: 'Category restored' });
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+});
+
+router.delete('/:id/purge', async (req, res) => {
+  try {
+    await Category.deleteOne({ _id: req.params.id });
+    res.json({ message: 'Category purged' });
   } catch (err) {
     res.status(400).json({ error: err.message });
   }

--- a/routes/products.js
+++ b/routes/products.js
@@ -145,5 +145,7 @@ router.get('/:id', async (req, res) => {
 router.post('/', productCtrl.createProduct);
 router.put('/:id', productCtrl.updateProduct);
 router.delete('/:id', productCtrl.deleteProduct);
+router.post('/:id/restore', productCtrl.restoreProduct);
+router.delete('/:id/purge', productCtrl.purgeProduct);
 
 module.exports = router;

--- a/scripts/migrate-soft-delete.js
+++ b/scripts/migrate-soft-delete.js
@@ -1,0 +1,25 @@
+require('dotenv').config();
+const mongoose = require('mongoose');
+const Product = require('../models/Product');
+const Category = require('../models/Category');
+const Brand = require('../models/Brand');
+
+const uri = process.env.MONGO_URI || process.env.MONGODB_URI || 'mongodb://localhost:27017/hipc';
+
+async function run() {
+  await mongoose.connect(uri);
+  const models = [Product, Category, Brand];
+  for (const model of models) {
+    await model.updateMany(
+      { isDeleted: { $exists: false } },
+      { $set: { isDeleted: false, deletedAt: null, deletedBy: null } }
+    );
+  }
+  console.log('Soft delete migration completed');
+  await mongoose.disconnect();
+}
+
+run().catch(err => {
+  console.error(err);
+  process.exit(1);
+});

--- a/views/admin/products-static.hbs
+++ b/views/admin/products-static.hbs
@@ -39,6 +39,12 @@
     </a>
   </div>
 
+  <div class="tabs my-4">
+    <a href="/admin/products?view=active" class="btn">Đang hoạt động</a>
+    <a href="/admin/products?view=all" class="btn">Tất cả</a>
+    <a href="/admin/products?view=trash" class="btn">Thùng rác</a>
+  </div>
+
   <!-- 3. Bảng products -->
   <div class="mt-2 text-right">Tổng sản phẩm: <span id="productCount">0</span></div>
   <div class="table-container">


### PR DESCRIPTION
## Summary
- add reusable Mongoose soft delete plugin and migration script
- convert products and categories APIs to use soft deletion with restore/purge endpoints
- expose trash views in admin UI with client-side actions

## Testing
- `npm test` (fails: Missing script "test")
- `npm run migrate:soft` (fails: connect ECONNREFUSED ::1:27017)


------
https://chatgpt.com/codex/tasks/task_e_68adda10c9548330a96ab9a0eaa8acbc